### PR TITLE
feat : 받은 결재 조회 기능 구현

### DIFF
--- a/src/components/common/Sidebar.vue
+++ b/src/components/common/Sidebar.vue
@@ -144,7 +144,7 @@ const menuItems = [
         hrefs: ['../approvals'],
         requireRole: ['MASTER', 'HR_MANAGER']
       },
-      { label: '문서함', hrefs: ['../approval/inbox'] }
+      { label: '문서함', hrefs: ['../approvals/inbox'] }
     ]
   },
   {

--- a/src/features/approvals/api.js
+++ b/src/features/approvals/api.js
@@ -9,3 +9,13 @@ export function getApprovals(approveListRequest, pageRequest = {}) {
         }
     });
 }
+
+/* 2. 받은 문서함 결재 내역 불러오기 */
+export function getReceivedApprovals(approveListRequest, pageRequest = {}) {
+    return api.get('/approval/documents/received', {
+        params: {
+            ...approveListRequest,
+            ...pageRequest
+        }
+    });
+}

--- a/src/features/approvals/components/ApprovalHeaderWithTabs.vue
+++ b/src/features/approvals/components/ApprovalHeaderWithTabs.vue
@@ -1,0 +1,88 @@
+<script setup>
+const props = defineProps({
+  headerItems: {
+    type: Array,
+    default: () => []
+  },
+  showTabs: {
+    type: Boolean,
+    default: true
+  },
+  submitButtons: {
+    type: Array,
+    default: () => []
+  },
+  tabs: {
+    type: Array,
+    default: () => []
+  }
+});
+
+</script>
+
+<template>
+  <div>
+    <div class="main-header">
+      <div class="header-area">
+        <div class="page-header">
+          <component
+            v-for="(item, idx) in headerItems"
+            :key="idx"
+            :is="item.to ? 'router-link' : 'div'"
+            :to="item.to"
+            class="router-link page-title"
+            @click="!item.to && $emit('tab-click', item.label)"
+          >
+            <h1 :class="{ active: item.active }">{{ item.label }}</h1>
+          </component>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.header-area {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 36px;
+  padding: 0 40px;
+}
+
+.header-area h1 {
+  font-size: 2rem;
+  font-weight: bold;
+  color: var(--font-main);
+  margin: 0;
+}
+
+.header-area p {
+  color: var(--label-color);
+  margin: 8px 0 0 0;
+  font-size: 1rem;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 40px;
+}
+
+.page-header h1 {
+  color: var(--font-none);
+}
+.page-header .active {
+  color: var(--font-main);
+}
+
+.page-title a {
+  all: unset;
+  cursor: pointer;
+}
+
+.router-link {
+  all: unset;
+  cursor: pointer;
+}
+</style>

--- a/src/features/approvals/components/ReceivedApproval.vue
+++ b/src/features/approvals/components/ReceivedApproval.vue
@@ -1,0 +1,326 @@
+<script setup>
+import {ref, onMounted, computed, watch} from 'vue'
+import BaseTable from '@/components/common/BaseTable.vue'
+import Pagination from "@/components/common/Pagination.vue"
+import Filter from "@/components/common/Filter.vue"
+import TabNav from '@/components/common/NavigationTab.vue'
+import {getReceivedApprovals} from "@/features/approvals/api.js";
+
+/* 결재 목록 데이터 */
+const approvals = ref([])
+const pagination = ref({ totalPage: 0 })
+const currentPage = ref(1)
+
+/* 탭 항목 정의 */
+// 현재 선택된 탭
+const selectedTab = ref('ALL');
+
+// 탭의 종류
+const tabItems = [
+  { label: '전체', value: 'ALL', icon: 'fa-building' },
+  { label: '근태', value: 'ATTENDANCE', icon: 'fa-sitemap' },
+  { label: '영수증', value: 'RECEIPT', icon: 'fa-receipt' },
+  { label: '품의', value: 'PROPOSAL', icon: 'fa-user-tie' },
+  { label: '취소', value: 'CANCEL', icon: 'fa-shield-alt' }
+]
+
+/* 필터링 정의 */
+// 필터 바인딩 값
+const filterValues = ref({
+  approveType: null,
+  receiptType: null,
+  statusType: null,
+  title: '',
+  employeeName: '',
+  departmentName: null,
+  completeAt: null,
+  sort: null
+})
+
+// 기본 필터
+const baseFilterOptions = [
+  {
+    key: 'statusType',
+    label: '결재 상태',
+    icon: 'fa-clipboard-check',
+    type: 'select',
+    options: ['전체', '대기', '승인', '반려']
+  },
+  {
+    key: 'title',
+    label: '제목',
+    icon: 'fa-heading',
+    type: 'input',
+    placeholder: '제목 검색'
+  },
+  {
+    key: 'employeeName',
+    label: '기안자',
+    icon: 'fa-user',
+    type: 'input',
+    placeholder: '기안자 이름 입력'
+  },
+  {
+    key: 'departmentName',
+    label: '부서',
+    icon: 'fa-building',
+    type: 'select',
+    options: ['전체', '기획팀', '인사팀', '재무팀', '프론트엔드팀', '백엔드팀', '데이터팀', '영업팀', '디지털마케팅팀']
+  },
+  {
+    key: 'completeAt',
+    label: '등록일',
+    icon: 'fa-calendar-day',
+    type: 'date-range'
+  },
+  {
+    key: 'sort',
+    label: '처리일',
+    icon: 'fa-sort',
+    type: 'select',
+    options: ['최신순', '오래된순']
+  }
+]
+
+/* 동적 필터 */
+// 영수증 필터
+const receiptTypeFilter = {
+  key: 'receiptType',
+  label: '영수증 종류',
+  icon: 'fa-receipt',
+  type: 'select',
+  options: ['전체', '식비', '출장비', '비품 구입비', '기타']
+}
+
+// 근태 필터
+const attendanceTypeFilter = {
+  key: 'approveType',
+  label: '근태 종류',
+  icon: 'fa-clock',
+  type: 'select',
+  options: ['전체', '출퇴근 정정', '재택 근무', '초과 근무', '출장', '휴가']
+}
+
+// 동적 필터 조합
+const visibleFilterOptions = computed(() => {
+  const filters = [...baseFilterOptions]
+
+  if (selectedTab.value === 'RECEIPT') {
+    filters.splice(1, 0, receiptTypeFilter)
+  } else if (selectedTab.value === 'ATTENDANCE') {
+    filters.splice(1, 0, attendanceTypeFilter)
+  }
+
+  return filters
+})
+
+/* 테이블 컬럼 정의 */
+const columns = [
+  { key: 'statusType', label: '상태' },
+  { key: 'approveTitle', label: '제목' },
+  { key: 'approveType', label: '종류' },
+  { key: 'employeeName', label: '작성자' },
+  { key: 'departmentName', label: '부서' },
+  { key: 'createAt', label: '작성일' },
+  { key: 'completeAt', label: '처리일' },
+  { key: 'action', label: '상세' }
+]
+
+/* 결재 상태과 결재 타입 매핑을 위한 부분 */
+// 승인 종류
+const statusTypeMap = {
+  'PENDING': '대기',
+  'ACCEPTED': '승인',
+  'REJECTED': '반려'
+};
+
+// 결재 종류
+const approveTypeMap = {
+  'PROPOSAL': '품의',
+  'RECEIPT': '영수증',
+  'BUSINESSTRIP': '출장',
+  'VACATION': '휴가',
+  'REMOTEWORK': '재택 근무',
+  'OVERTIME': '초과 근무',
+  'WORKCORRECTION': '출퇴근 정정',
+  'CANCEL': '취소'
+};
+
+// 상태 아이디를 기반으로 승인, 대기, 출장 구분
+function convertStatusToId(status) {
+  const statusMap = {
+    '대기': 1,
+    '승인': 2,
+    '반려': 3
+  };
+
+  return statusMap[status] || null;
+}
+
+// 정렬 변환
+function convertSort(sort) {
+  const statusMap = {
+    '최신순': 'desc',
+    '오래된순': 'asc'
+  };
+
+  return statusMap[sort] || null;
+}
+
+// approveType 변환
+function convertApproveType(tab, approveTypeLabel) {
+  const map = {
+    'ATTENDANCE': {
+      '출퇴근 정정': 'WORKCORRECTION',
+      '초과 근무': 'OVERTIME',
+      '재택 근무': 'REMOTEWORK',
+      '출장': 'BUSINESSTRIP',
+      '휴가': 'VACATION'
+    },
+    'RECEIPT': {
+      '영수증': 'RECEIPT'
+    },
+    'PROPOSAL': {
+      '품의': 'PROPOSAL'
+    },
+    'CANCEL': {
+      '취소': 'CANCEL'
+    }
+  };
+
+  if (approveTypeLabel === '전체') return null;
+
+  return map[tab]?.[approveTypeLabel] || null;
+}
+
+
+// 영수증 변환
+function convertReceipt(receiptType) {
+  const statusMap = {
+    '식비': 'MEALEXPENSE',
+    '출장비': 'TRAVELEXPENSE',
+    '비품 구입비': 'SUPPLYPURCHASE',
+    '기타': 'MISCELLANEOUS'
+  };
+
+  return statusMap[receiptType] || null;
+}
+
+// 부서 변환
+function convertDepartment(departmentName) {
+  const statusMap = {
+    '전체': null,
+    '인사팀': 10,
+    '재무팀': 11,
+    '프론트엔드팀': 12,
+    '백엔드팀': 13,
+    '데이터팀': 14,
+    '영업팀': 15,
+    '디지털마케팅팀': 16
+  };
+
+  return statusMap[departmentName] || null;
+}
+
+const displayApprovals = computed(() => {
+  return approvals.value.map(item => ({
+    ...item,
+    statusType: statusTypeMap[item.statusType] || item.statusType,
+    approveType: approveTypeMap[item.approveType] || item.approveType
+  }));
+});
+
+
+/* 탭 클릭 시 로직 */
+// 탭 클릭
+const handleTabClick = () => {
+  resetFilters(); // 필터들 다 초기화 하기
+  currentPage.value = 1 // 1번재 페이지로 넘어가기
+  fetchReceivedApprovals()// (); // 결재 문서 가져오기
+}
+
+// 필터 조건을 초기화
+const resetFilters = () => {
+  filterValues.value = {
+    approveType: null,
+    receiptType: null,
+    statusType: null,
+    approveTitle: '',
+    employeeName: '',
+    departmentName: null,
+    startDate: null,
+    endDate: null,
+    sort: null
+  }
+}
+
+/* 필터 검색 이벤트 */
+const handleSearch = (filters) => {
+  currentPage.value = 1;
+  fetchReceivedApprovals();
+}
+
+/* 결재 문서를 가져오는 api  */
+async function fetchReceivedApprovals() {
+  try {
+    const approveListRequest = {
+      tab: selectedTab.value,
+      approveType:  convertApproveType(selectedTab.value, filterValues.value.approveType) || null ,
+      receiptType: convertReceipt(filterValues.value.receiptType) || null,
+      status: convertStatusToId(filterValues.value.statusType),
+      title: filterValues.value.title || null,
+      employeeName: filterValues.value.employeeName || null,
+      deptId: convertDepartment(filterValues.value.departmentName) || null,
+      startDate: filterValues.value.completeAt_start || null,
+      endDate: filterValues.value.completeAt_end || null,
+      sort:  convertSort(filterValues.value.sort) || null
+    }
+
+    const pageRequest = {
+      page: currentPage.value,
+      size: 10
+    }
+
+    const res = await getReceivedApprovals(approveListRequest, pageRequest);
+    approvals.value = res.data.data.approveDTO;
+    pagination.value.totalPage = res.data.data.pagination.totalPage;
+
+  } catch (e) {
+    console.error('결재 내역 불러오기 실패:', e)
+  }
+}
+
+watch(currentPage, () => {
+  fetchReceivedApprovals();
+});
+
+/* api 호출하기 */
+onMounted(fetchReceivedApprovals);
+</script>
+
+<template>
+  <section>
+    <TabNav
+      :tabs="tabItems"
+      v-model:selected="selectedTab"
+      @tab-click="handleTabClick"
+    />
+
+    <Filter
+      :filters="visibleFilterOptions"
+      v-model="filterValues"
+      @search="handleSearch"
+    />
+
+    <BaseTable
+      :columns="columns"
+      :rows="displayApprovals"
+    />
+
+    <Pagination
+      v-if="pagination.totalPage"
+      :totalPages="pagination.totalPage"
+      v-model="currentPage"
+    />
+  </section>
+</template>

--- a/src/features/approvals/router.js
+++ b/src/features/approvals/router.js
@@ -4,4 +4,9 @@ export const approvalsRoutes = [
         name: 'ApprovalsList',
         component: () => import('@/features/approvals/views/ApprovalList.vue')
     },
+    {
+        path: 'approvals/inbox',
+        name: 'ApprovalsList',
+        component: () => import('@/features/approvals/views/MyApprovalList.vue')
+    },
 ];

--- a/src/features/approvals/views/MyApprovalList.vue
+++ b/src/features/approvals/views/MyApprovalList.vue
@@ -1,68 +1,37 @@
 <script setup>
-import BaseTable from '@/components/common/BaseTable.vue'
-import { ref, onMounted } from 'vue'
-import Pagination from "@/components/common/Pagination.vue";
-import HeaderWithTabs from "@/components/common/HeaderWithTabs.vue";
-import EmployeeFilter from "@/components/common/Filter.vue";
-import Filter from "@/components/common/Filter.vue";
+import { ref } from 'vue'
 
-const approvals = ref([])
+import HeaderWithTabs from "@/components/common/HeaderWithTabs.vue"
+import ReceivedApproval from "@/features/approvals/components/ReceivedApproval.vue"
+import SentApproval from "@/features/approvals/components/SentApproval.vue"
+import ApprovalHeaderWithTabs from "@/features/approvals/components/ApprovalHeaderWithTabs.vue";
 
-/* 컬럼명들 */
-const columns = [
-  { key: 'status', label: '상태' },
-  { key: 'approveTitle', label: '제목' },
-  { key: 'type', label: '종류' },
-  { key: 'employeeName', label: '작성자' },
-  { key: 'departmentName', label: '부서' },
-  { key: 'createAt', label: '작성일' },
-  { key: 'completeAt', label: '처리일' },
-  { key: 'detail', label: '상세' }
-]
+/* 현재 활성화 되어 있는 탭 */
+const currentTab = ref('RECEIVED')
 
-/* 전체 결재 내역 */
-onMounted(() => {
-  approvals.value = [
-    {
-      status: '대기',
-      title: '연차 신청서',
-      writer: '김태훈',
-      type: '휴가',
-      department: '개발팀',
-      createdAt: '2024-06-15',
-      processedAt: '-'
-    },
-    {
-      status: '승인',
-      title: '출장비 청구서',
-      writer: '이하나',
-      type: '출장',
-      department: '영업팀',
-      createdAt: '2024-06-12',
-      processedAt: '2024-06-13'
-    }
-  ]
-})
-
+/* 탭 클릭 핸들러 */
+const handleTabClick = (tabLabel) => {
+  currentTab.value = tabLabel === '받은 문서함' ? 'RECEIVED' : 'SENT'
+}
 </script>
 
 <template>
-  <section>
-    <!-- 1. 탭이 있는 부분 -->
-    <HeaderWithTabs
-      :headerItems="[
-        { label: '전체 결재 목록', active: true }
-      ]"
-      :showTabs="false"
-    />
+  <!-- 내 결재 내역 탭 나누기 -->
+  <ApprovalHeaderWithTabs
+    :headerItems="[
+      { label: '받은 문서함', active: currentTab === 'RECEIVED' },
+      { label: '보낸 문서함', active: currentTab === 'SENT' }
+    ]"
+    :showTabs="false"
+    @tab-click="handleTabClick"
+  />
 
-    <!-- 2. 필터 -->
-    <Filter :filters="filterOptions" v-model="filterValues" @search="handleSearch" />
+  <!-- 받은 문서함 -->
+  <ReceivedApproval v-if="currentTab === 'RECEIVED'" />
 
-    <!-- 3. 결재 목록 표 -->
-    <BaseTable :columns="columns" :rows="approvals" :classMap="statusClassMap" />
-
-    <!-- 4. 페이징 처리 -->
-    <Pagination/>
-  </section>
+  <!-- 보낸 문서함 -->
+  <SentApproval v-else />
 </template>
+
+<style scoped>
+</style>


### PR DESCRIPTION
closes #3

---

📌 개요
받은 결재 목록 조회 페이지 구현

🔨 주요 변경 사항
- `Sidebar`에 문서함 경로 추가
- `api.js`에 결재 내역을 불러오는 함수 설정 
- `router.js`에 나의 결재함 router 생성
- `MyApprovalList`생성 (보낸 문서, 결재 문서 분류)
- `ApprovalHeaderWithTabs` 생성 (탭만 전환하기 위해서 생성) 
- `ReceivedApproval` 컴포넌트 생성 
  (받은 문서와 보낸 문서 형태는 비슷하지만 내용이나 필터가 다르기 때문에 컴포넌트로 분리)

✅ 리뷰 요청 사항
페이지 확인

⭐ 관련 이슈
#3
