### PR TITLE
feat : 보낸 문서 조회 기능

### DIFF
--- a/src/features/approvals/api.js
+++ b/src/features/approvals/api.js
@@ -19,3 +19,13 @@ export function getReceivedApprovals(approveListRequest, pageRequest = {}) {
         }
     });
 }
+
+/* 3. 보낸 문서함 결재 내역 불러오기 */
+export function getSentApprovals(draftApproveListRequest, pageRequest = {}) {
+    return api.get('/approval/documents/draft', {
+        params: {
+            ...draftApproveListRequest,
+            ...pageRequest
+        }
+    });
+}


### PR DESCRIPTION
closes #4 

---

📌 개요
보낸 문서 결재 조회 구현

🔨 주요 변경 사항
- `ApprovalList`에 상세 조회 경로 이동 부분 추가 후 주석 처리 (추후에 수정)
- `SentApprovals` 보낸 결재 문서 조회 컴포넌트
- `approvals/api.js`에 보낸 결재 문서 조회 백엔드 api 연결

✅ 리뷰 요청 사항

⭐ 관련 이슈
#4
