### PR TITLE
refactor: 목록 조회 페이지 부서 필터 수정

### DIFF
--- a/src/components/common/Pagination.vue
+++ b/src/components/common/Pagination.vue
@@ -90,7 +90,14 @@ const visiblePages = computed(() => {
 const updateSliderPosition = () => {
   nextTick(() => {
     const buttons = pagination.value?.querySelectorAll('.page-btn') || [];
-    const activeIndex = visiblePages.value.findIndex((p) => p === props.modelValue);
+    let activeIndex = 0;
+    for (let i = 0; i < visiblePages.value.length; i++) {
+      const p = visiblePages.value[i];
+      if (p === '...') continue;
+      if (p === props.modelValue) break;
+      activeIndex++;
+    }
+
     const activeBtn = buttons[activeIndex];
     if (!activeBtn) return;
 

--- a/src/components/common/Sidebar.vue
+++ b/src/components/common/Sidebar.vue
@@ -377,7 +377,6 @@ onUnmounted(() => {
       width 0.4s ease,
       transform 0.6s ease,
       padding 0.3s ease;
-  transform: translateX(0);
 }
 
 .sidebar-header {

--- a/src/features/employee/views/ContractListView.vue
+++ b/src/features/employee/views/ContractListView.vue
@@ -17,9 +17,6 @@ const appliedFilterValues = ref({});
 const contracts = ref([]);
 
 const showModal = ref(false);
-// const workDetails = ref(null);
-
-const vacationTypeOptions = ref([]);
 
 const columns = [
   {key: 'empNo', label: '사번'},
@@ -37,8 +34,8 @@ const columns = [
     }
   },
   {key: 'createdAt', label: '등록일', format: val => val.split('T')[0]},
-  // {key: 's3Key', label: 's3Key', hidden: true},
   {key: 'action', label: '다운로드'},
+  /* TODO: 베이스테이블 수정 후 "삭제" 버튼 추가*/
 ];
 
 // 필터
@@ -126,19 +123,21 @@ const req = ref({
       }
 });
 
+const initializeRequest = () => {
+  req.value = {
+    empId: null,
+    type: null,
+    salary: null,
+    attachment: {
+      s3Key: null,
+      type: null
+    }
+  };
+}
+
 const openCreateModal = () => {
+  initializeRequest()
   showModal.value = true;
-
-  // loadingDetails.value = true;
-  //
-  // try {
-  //   workDetails.value = await getWorkDetails(workId);
-  // } catch (error) {
-  //   workDetails.value = null;
-  // } finally {
-  //   loadingDetails.value = false;
-  // }
-
 };
 
 const downloadFile = async (row) => {
@@ -162,35 +161,34 @@ const closeModal = () => {
 * 2. 파일 업로드 로직 및 form 작성
 * */
 const modalSections = computed(() => {
-  const salaryIsEditable = req.value.type === 'SALARY_AGREEMENT'
+  const salaryEditable = req.value.type === 'SALARY_AGREEMENT';
 
-      return [
+  return [
+    {
+      title: '계약서 정보',
+      icon: 'fa-info-circle',
+      layout: 'two-column',
+      fields: [
+        {key: 'empId', label: '사원ID', type: 'number', editable: true, required: true, placeholder: '1'},
+        {key: 'file', label: '첨부 파일', type: 'file', editable: true, required: true},
         {
-          title: '계약서 정보',
-          icon: 'fa-info-circle',
-          layout: 'two-column',
-          fields: [
-            {key: 'empId', label: '사원ID', type: 'number', editable: true, required: true, placeholder: '1'}, // 조직도 조회
-            {key: 'file', label: '첨부 파일', type: 'file', editable: true, required: true},
-            {
-              key: 'type', label: '계약서 종류', type: 'select', editable: true, required: true, options: [
-                {label: '선택', value: null},
-                {label: '근로계약서', value: 'EMPLOYEE_AGREEMENT'},
-                {label: '연봉계약서', value: 'SALARY_AGREEMENT'}
-              ]
-            },
-            {
-              key: 'salary',
-              label: '연봉',
-              type: 'input',
-              editable: salaryIsEditable,
-              placeholder: '40000000'
-            },
-          ]
+          key: 'type', label: '계약서 종류', type: 'select', editable: true, required: true, options: [
+            {label: '근로계약서', value: 'EMPLOYEE_AGREEMENT'},
+            {label: '연봉계약서', value: 'SALARY_AGREEMENT'},
+          ],
+          value: req.value.type
+        },
+        {
+          key: 'salary',
+          label: '연봉',
+          type: 'input',
+          editable: salaryEditable,
+          placeholder: '40000000'
         }
       ]
     }
-);
+  ];
+});
 
 const handleRegisterSubmit = async (req) => {
   try {
@@ -202,11 +200,18 @@ const handleRegisterSubmit = async (req) => {
   }
 };
 
+const handleHeaderButton = (event) => {
+  if (event.value === 'create') {
+    openCreateModal();
+  }
+}
+
 watch(() => req.value.type, (newType) => {
   if (newType !== 'SALARY_AGREEMENT') {
     req.value.salary = null;
   }
-});
+}, { immediate: true });
+
 </script>
 
 <template>
@@ -215,9 +220,9 @@ watch(() => req.value.type, (newType) => {
         :headerItems="[
         { label: '계약서 목록 조회', to: '/contracts', active: true },
     ]"
-        :submitButtons="[{label: '계약서 등록', icon: 'fa-file-signature', variant: 'blue'}]"
+        :submitButtons="[{label: '계약서 등록', icon: 'fa-file-signature', event: 'click', value: 'create', variant: 'blue'}]"
         :showTabs="false"
-        @click="openCreateModal"
+        @click="handleHeaderButton"
     />
     <Filter :filters="filterOptions" v-model="filterValues" @search="handleSearch"/>
 

--- a/src/features/works/composable/useAttendance.js
+++ b/src/features/works/composable/useAttendance.js
@@ -40,7 +40,6 @@ export function useAttendance() {
     async function fetchTodayAttendance() {
         try {
             const resp = await getMyTodaysAttendance()
-            console.log(resp)
             todaysWork.value = resp.attendance
             isAttended.value = !!todaysWork.value
             hasAmHalfDayoff.value = !!resp.amHalfDayoff
@@ -48,8 +47,8 @@ export function useAttendance() {
             hasDayoff.value = !!resp.dayoff
             hasVacation.value = !!resp.vacation
             hasApprovedWork.value = !!resp.approvedWork
-            isWeekend.value = resp.isWeekend
-            isHoliday.value = resp.isHoliday
+            isWeekend.value = resp.weekend
+            isHoliday.value = resp.holiday
         } catch (e) {
             console.error('출근 상태 조회 실패', e)
         }

--- a/src/features/works/views/WorkListView.vue
+++ b/src/features/works/views/WorkListView.vue
@@ -5,7 +5,14 @@ import Filter from "@/components/common/Filter.vue";
 import BaseTable from "@/components/common/BaseTable.vue";
 import SideModal from "@/components/common/SideModal.vue";
 import HeaderWithTabs from "@/components/common/HeaderWithTabs.vue";
-import {getPositions, getVacationTypes, getWorkDetails, getWorks, getWorkTypes} from "@/features/works/api.js";
+import {
+  getDepartments,
+  getPositions,
+  getVacationTypes,
+  getWorkDetails,
+  getWorks,
+  getWorkTypes
+} from "@/features/works/api.js";
 
 const currentPage = ref(1);
 const pagination = ref({currentPage: 1, totalPage: 1});
@@ -25,17 +32,7 @@ const childWorkTypeOptions = ref([]);
 
 const workTypeIdMap = ref({VACATION: null, ADDITIONAL: null});
 
-const deptOptions = ref([
-  {label: '전체', value: null},
-  {label: '테크놀로지(주)', value: 1},
-  {label: '인사팀', value: 10},
-  {label: '재무팀', value: 11},
-  {label: '프론트엔드팀', value: 12},
-  {label: '백엔드팀', value: 13},
-  {label: '데이터팀', value: 14},
-  {label: '영업팀', value: 15},
-  {label: '디지털마케팅팀', value: 16},
-]);
+const departmentTree = ref([]);
 
 const columns = computed(() => {
   const baseColumns = [
@@ -76,11 +73,11 @@ const columns = computed(() => {
 const baseFilterOptions = computed(() => [
   {key: 'empNo', type: 'input', label: '사번', icon: 'fa-id-badge', placeholder: '사번 입력'},
   {key: 'empName', type: 'input', label: '이름', icon: 'fa-user', placeholder: '이름 입력'},
-  {key: 'deptId', type: 'select', label: '부서', icon: 'fa-building', options: deptOptions.value},
+  {key: 'deptId', type: 'tree', label: '부서', icon: 'fa-building', options: departmentTree.value},
   {key: 'positionId', type: 'select', label: '직위', icon: 'fa-user-tie', options: positionOptions.value},
-  {key: 'startAt', type: 'date-range', label: '시작 일시', icon: 'fa-calendar-day'},
+  {key: 'startAt', type: 'date-range', label: '출근 일시', icon: 'fa-calendar-day'},
   {
-    key: 'order', type: 'select', label: '정렬 (시작 일시)', icon: 'fa-filter', options: [
+    key: 'order', type: 'select', label: '정렬 (출근 일시)', icon: 'fa-filter', options: [
       {label: '오름차순', value: 'ASC'},
       {label: '내림차순', value: 'DESC'}
     ]
@@ -159,6 +156,9 @@ const additionalWorkMap = {
 };
 
 onMounted(async () => {
+  const depts = await getDepartments();
+  departmentTree.value = depts.data?.departmentInfoDTOList || [];
+
   const positions = await getPositions();
   positionOptions.value = [{label: '전체', value: null}, ...positions.map(p => ({label: p.name, value: p.positionId}))];
 


### PR DESCRIPTION
closes #102 

---

📌 개요
- 목록 조회 페이지 부서 필터 수정
- 이 외 다양한 오류 사항 수정 (세부 내용 하단에 작성)

🔨 주요 변경 사항
- 목록 조회 페이지 부서 필터 수정: 트리 필터 반영 및 하드코딩 삭제 후 API 연동 (사원, 계약서, 발령, 출퇴근)
- 페이지네이션 컴포넌트: 스타일 꼬이는 문제 수정 (예시: 현재 5페이지를 보고 있지만 스타일은 6페이지를 가리킴)
- 사이드바: 알림 패널이 뜨지 않으며 출퇴근 모달이 사이드바 안에 갇히는 문제 수정 (아직 merge되지 않은 운경님 수정사항)
- 목록 조회 페이지에서 버튼이 아닌 헤더만 클릭해도 사이드 모달이 열리던 문제 수정

✅ 리뷰 요청 사항

⭐ 관련 이슈
#18, #21, #22, #23, #102