### PR TITLE
feat : 결재 문서 승인, 반려 기능 구현

### DIFF
--- a/src/features/approvals/api.js
+++ b/src/features/approvals/api.js
@@ -34,3 +34,11 @@ export function getSentApprovals(draftApproveListRequest, pageRequest = {}) {
 export function getApprovalDetail(documentId) {
     return api.get(`/approval/documents/${documentId}`);
 }
+
+/* 5. 결재 문서 작성 */
+
+/* 6. 결재 문서 승인/반려 */
+export function approveOrReject(approvalConfirmRequest) {
+    return api.patch(`/approval/decision`, approvalConfirmRequest);
+}
+

--- a/src/features/approvals/components/approveType/CancelForm.vue
+++ b/src/features/approvals/components/approveType/CancelForm.vue
@@ -18,11 +18,6 @@ const props = defineProps({
   }
 });
 
-/* 취소 사유 */
-const cancelForm = ref({
-  cancelReason: ''
-});
-
 /* 부모 결재 내역 */
 const parentApprove = ref(null);
 
@@ -89,7 +84,8 @@ onMounted(async () => {
     <div class="form-grid">
       <div class="form-group full-width">
         <label class="form-label required">취소 사유</label>
-        <textarea v-model="cancelForm.cancelReason" class="form-textarea" required></textarea>
+        <input v-model="formData.cancelReason" class="form-textarea" readonly></input>
+<!--        <textarea v-model="cancelForm.cancelReason" class="form-textarea" required></textarea>-->
       </div>
     </div>
   </div>
@@ -134,7 +130,6 @@ onMounted(async () => {
 
 .form-textarea:focus {
   outline: none;
-  color: var(--blue-300);
   box-shadow: 0 0 0 4px var(--form-shadow);
   transform: translateY(-1px);
 }
@@ -162,6 +157,7 @@ onMounted(async () => {
 
 .original-form-wrapper {
   border: 1px solid var(--blue-100);
+  background-color: var(--color-surface);
   padding: 20px;
   border-radius: 10px;
 }

--- a/src/features/approvals/router.js
+++ b/src/features/approvals/router.js
@@ -12,6 +12,6 @@ export const approvalsRoutes = [
     {
         path: '/approval/detail/:documentId',
         name: 'ApprovalDetail',
-        component: () => import('@/features/approvals/views/ApprovalDetail.vue')
+        component: () => import('@/features/approvals/views/ApproveDetailActionView.vue')
     }
 ];

--- a/src/features/approvals/views/ApproveDetailActionView.vue
+++ b/src/features/approvals/views/ApproveDetailActionView.vue
@@ -1,53 +1,106 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import {ref, onMounted, computed, watch, watchEffect} from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import FormSection from '@/features/approvals/components/FormSection.vue'
 import ApprovalSideSection from '@/features/approvals/components/ApprovalSideSection.vue'
-import {getApprovalDetail} from "@/features/approvals/api.js";
+import { approveOrReject, getApprovalDetail } from "@/features/approvals/api.js"
+import { useAuthStore } from "@/stores/auth.js"
 
 const router = useRouter();
 const route = useRoute();
+const authStore = useAuthStore();
 
-const approveType = ref('');
-const status = ref('');
+/* 없는 문서인 경우를 구분하기 위한 변수 */
+const fetchError = ref(false);
+
+/* 결재에서 필요한 변수들 */
 const approval = ref(null);
+const status = ref('');
+const approveType = ref('');
+const loading = ref(false);
+const myEmpId = computed(() => authStore.userId);
+const myApproveLineListId = ref(null)
 
-/* 글자 변환하기 */
-// 결재 상태를 변환
+/* 상태 변환 함수 */
 const statusText = (statusType) => {
   switch (statusType) {
-    case 'PENDING':
-      return '대기'
-    case 'ACCEPTED':
-      return '승인'
-    case 'REJECTED':
-      return '반려'
+    case 'PENDING': return '대기'
+    case 'ACCEPTED': return '승인'
+    case 'REJECTED': return '반려'
   }
 }
 
-// 결재 문서 타입을 변환
 const approveTypeText = (approveType) => {
   switch (approveType) {
-    case 'WORKCORRECTION':
-      return '출퇴근 정정 신청서'
-    case 'OVERTIME':
-      return '초과 근무 신청서'
-    case 'REMOTEWORK':
-      return '재택 근무 신청서'
-    case 'BUSINESSTRIP':
-      return '출장 신청서'
-    case 'VACATION':
-      return '휴가 신청서'
-    case 'PROPOSAL':
-      return '품의서'
-    case 'RECEIPT':
-      return '영수증'
-    case 'CANCEL':
-      return '취소'
+    case 'WORKCORRECTION': return '출퇴근 정정 신청서'
+    case 'OVERTIME': return '초과 근무 신청서'
+    case 'REMOTEWORK': return '재택 근무 신청서'
+    case 'BUSINESSTRIP': return '출장 신청서'
+    case 'VACATION': return '휴가 신청서'
+    case 'PROPOSAL': return '품의서'
+    case 'RECEIPT': return '영수증'
+    case 'CANCEL': return '취소'
   }
 }
 
-/* 이전 페이지로 넘어가는 함수 */
+/* 상세 조회 api 호출 */
+async function fetchApproval() {
+  try {
+    fetchError.value = false;
+    const documentId = route.params.documentId;
+    const res = await getApprovalDetail(documentId);
+    approval.value = res.data.data;
+    status.value = statusText(approval.value.approveDTO.statusType);
+    approveType.value = approveTypeText(approval.value.approveDTO.approveType);
+  } catch (e) {
+    console.error("상세 조회 실패:", e)
+    fetchError.value = true;
+  }
+}
+
+/* 내 결재선 찾기 */
+watchEffect(() => {
+  if (!approval.value) return;
+
+  const groupList = approval.value.approveLineGroupDTO;
+  if (!Array.isArray(groupList)) return;
+
+  const empIdNum = Number(myEmpId.value);
+  for (const group of groupList) {
+    const target = group.approveLineListDTOs
+      .find(line => Number(line.empId) === empIdNum);
+    if (target) {
+      myApproveLineListId.value = target.approveLineListId;
+      return;
+    }
+  }
+
+  myApproveLineListId.value = null;
+});
+
+
+/* 승인/반려를 처리하는 api */
+async function handleApprove(isApprove, reason) {
+  try {
+    loading.value = true
+
+    const payload = {
+      approveLineListId: myApproveLineListId.value,
+      isApproved: isApprove ? '승인' : '반려',
+      reason: reason
+    }
+
+    await approveOrReject(payload);
+    await fetchApproval();
+
+  } catch (err) {
+    console.error('승인/반려 실패:', err)
+  } finally {
+    loading.value = false
+  }
+}
+
+/* 문서함으로 돌아가기 */
 function goBack() {
   const from = route.query.from || window.history.state?.from
   if (from === 'list') {
@@ -57,23 +110,11 @@ function goBack() {
   }
 }
 
-/* 상세조회 api 가져오기 */
-async function fetchApproval() {
-  try {
-      const documentId = route.params.documentId;
-      const res = await getApprovalDetail(documentId);
-      approval.value = res.data.data;
-      status.value = statusText(approval.value.approveDTO.statusType);
-      approveType.value = approveTypeText(approval.value.approveDTO.approveType);
-    } catch (e) {
-      console.log(e);
-    }
-}
-
-onMounted(fetchApproval);
+onMounted(fetchApproval)
 </script>
 
 <template>
+
   <div v-if="approval" class="approval-header">
     <div class="header-left">
       <div class="icon-wrapper">
@@ -111,6 +152,8 @@ onMounted(fetchApproval);
           :approveFileDTO="approval.approveFileDTO"
           :formDetail="approval.formDetail"
           :isReadOnly="true"
+          @approve="(reason) => handleApprove(true, reason)"
+          @reject="(reason) => handleApprove(false, reason)"
         />
         <ApprovalSideSection
           :approveLineGroupDTO="approval.approveLineGroupDTO"
@@ -119,6 +162,11 @@ onMounted(fetchApproval);
         />
       </div>
     </div>
+  </div>
+
+  <div v-if="fetchError" class="error-message">
+    <i class="fas fa-exclamation-triangle"></i>
+    삭제되었거나 존재하지 않는 문서입니다.
   </div>
 </template>
 
@@ -139,6 +187,24 @@ onMounted(fetchApproval);
 .page-body {
   display: flex;
   gap: 32px;
+}
+
+.error-message {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.2rem;
+  color: var(--gray-400);
+  text-align: center;
+  gap: 16px;
+}
+
+.error-message i {
+  font-size: 2rem;
+  margin-bottom: 16px;
+  display: block;
 }
 
 .approval-header {
@@ -214,10 +280,12 @@ onMounted(fetchApproval);
   background-color: var(--label-pending);
   color: var(--text-on-label-pending);
 }
+
 .status-approved {
   background-color: var(--label-approved);
   color: var(--text-on-label-approved);
 }
+
 .status-rejected {
   background-color: var(--label-rejected);
   color: var(--text-on-label-rejected);


### PR DESCRIPTION
closes #138

---

📌 개요
결재 문서 승인, 반려 기능 구현

🔨 주요 변경 사항
- `FormSection`에 승인, 반려 내역 추가 
  (현재 대기 상태라면 무조건 승인, 반려가 뜨는데 이것은 추후에 내 차례가 끝나면 폼이 안 뜨게 수정할 예정
- `approvals/api.js`에서 결재 문서 승인/반려 api 연결 
- 취소 결재 디자인 수정 및 누락된 reason 추가
- `ApprovalDetail`에서 `ApproveDetailActionView`로 이름 변경 (승인도 처리되고 있는 뷰라서)

✅ 리뷰 요청 사항

⭐ 관련 이슈
#138
