### PR TITLE
refactor: 관리자 공지사항 수정 버튼 비활성화 + 공지 작성 및 수정 이후 상세페이지로 라우팅 처리 구현

### DIFF
--- a/src/features/announcement/views/AnnouncementCreateView.vue
+++ b/src/features/announcement/views/AnnouncementCreateView.vue
@@ -189,7 +189,7 @@ const handleSubmit = async () => {
   isSubmitting.value = true
 
   try {
-    await createAnnouncement({
+    const res = await createAnnouncement({
       title: form.value.title,
       content: form.value.content,
       attachments: uploadedFiles.value.map(file => ({
@@ -199,8 +199,9 @@ const handleSubmit = async () => {
       })),
     })
 
+    const createdId = res.data.data.announcementId
     alert('공지사항이 등록되었습니다.')
-    router.push('/announcement')
+    router.push(`/announcement/${createdId}`)
   } catch (err) {
     console.error('공지사항 등록 실패:', err)
     alert('공지사항 등록에 실패했습니다.')

--- a/src/features/announcement/views/AnnouncementDetailView.vue
+++ b/src/features/announcement/views/AnnouncementDetailView.vue
@@ -26,13 +26,21 @@
               </div>
 
               <!-- 수정/삭제 토글 버튼 -->
-              <div v-if="canEditOrDelete" class="action-toggle-wrapper">
+              <div v-if="canEdit || canDelete" class="action-toggle-wrapper">
                 <button class="btn-action-toggle" @click="toggleActions">
                   <i class="fas fa-ellipsis-v"></i>
                 </button>
                 <div v-if="showActions" class="action-menu" ref="actionMenuRef">
-                  <button class="action-item btn-edit" @click="handleEdit">공지 수정</button>
-                  <button class="action-item btn-delete" @click="handleDelete">공지 삭제</button>
+                  <button
+                      v-if="canEdit"
+                      class="action-item btn-edit"
+                      @click="handleEdit"
+                  >공지 수정</button>
+                  <button
+                      v-if="canDelete"
+                      class="action-item btn-delete"
+                      @click="handleDelete"
+                  >공지 삭제</button>
                 </div>
               </div>
             </div>
@@ -89,11 +97,10 @@
   </main>
 </template>
 
-
 <script setup>
-import {ref, onMounted, computed, onBeforeUnmount} from 'vue';
+import { ref, onMounted, computed, onBeforeUnmount } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import {deleteAnnouncement, getAnnouncementDetail} from '@/features/announcement/api';
+import { deleteAnnouncement, getAnnouncementDetail } from '@/features/announcement/api';
 import { getFileUrl } from '@/features/common/api.js';
 import { useAuthStore } from '@/stores/auth.js';
 
@@ -103,7 +110,7 @@ const authStore = useAuthStore();
 
 const detail = ref(null);
 const showActions = ref(false);
-const actionMenuRef = ref(null); // 드롭다운 메뉴
+const actionMenuRef = ref(null);
 
 const fetchDetail = async () => {
   try {
@@ -175,16 +182,17 @@ const getFileIcon = (fileName) => {
   return 'fas fa-paperclip';
 };
 
-const canEditOrDelete = computed(() =>
+const canEdit = computed(() =>
+    detail.value && authStore.userId === detail.value.empId
+);
+
+const canDelete = computed(() =>
     detail.value &&
-    (
-        authStore.userId === detail.value.empId ||
-        authStore.userRole.includes('MASTER')
-    )
+    (authStore.userId === detail.value.empId || authStore.userRole.includes('MASTER'))
 );
 
 const toggleActions = (event) => {
-  event.stopPropagation(); // 버튼 클릭 시 외부 클릭으로 인식되지 않도록
+  event.stopPropagation();
   showActions.value = !showActions.value;
 };
 

--- a/src/features/announcement/views/AnnouncementEditView.vue
+++ b/src/features/announcement/views/AnnouncementEditView.vue
@@ -232,7 +232,7 @@ const handleSubmit = async () => {
   isSubmitting.value = true
 
   try {
-    await modifyAnnouncement(route.params.announcementId, {
+    const res = await modifyAnnouncement(route.params.announcementId, {
       title: form.value.title,
       content: form.value.content,
       remainFileIdList: remainFileIdList.value,
@@ -243,8 +243,9 @@ const handleSubmit = async () => {
       })),
     })
 
+    const editId = res.data.data.announcementId
     alert('공지사항이 수정되었습니다.')
-    router.push('/announcement')
+    router.push(`/announcement/${editId}`)
   } catch (err) {
     console.error('공지사항 수정 실패:', err)
     alert('공지사항 수정에 실패했습니다.')


### PR DESCRIPTION
📌 개요
 관리자 공지사항 수정 버튼 비활성화 + 공지 작성 및 수정 이후 상세페이지로 라우팅 처리 구현
