### PR TITLE
refactor: 계약서 목록 조회 페이지 수정

### DIFF
--- a/src/features/employee/views/AppointListView.vue
+++ b/src/features/employee/views/AppointListView.vue
@@ -53,7 +53,7 @@ const baseFilterOptions = computed(() => [
     key: 'order',
     type: 'select',
     label: '정렬',
-    icon: 'fa-filter',
+    icon: 'fa-sort',
     options: [{label: '오름차순', value: 'ASC'}, {label: '내림차순', value: 'DESC'}]
   }
 ]);

--- a/src/features/employee/views/ContractListView.vue
+++ b/src/features/employee/views/ContractListView.vue
@@ -43,7 +43,7 @@ const columns = [
       }
     }
   },
-  {key: 'salary', label: '연봉', format: val => val == null ? '-' : val},
+  {key: 'salary', label: '연봉', format: val => val == null ? '-' : Math.round(val).toLocaleString() + "원"},
   {key: 'createdAt', label: '등록일', format: val => val.split('T')[0]},
   // { key: 'action', label: '다운로드' },
 ];
@@ -69,7 +69,7 @@ const filterOptions = computed(() => [
     key: 'order',
     type: 'select',
     label: '정렬 (등록일)',
-    icon: 'fa-filter',
+    icon: 'fa-sort',
     options: [
       {label: '오름차순', value: 'ASC'},
       {label: '내림차순', value: 'DESC'}
@@ -79,6 +79,7 @@ const filterOptions = computed(() => [
     key: 'type',
     type: 'select',
     label: '계약서 종류',
+    icon: 'fa-filter',
     options: [
       {label: '전체', value: null},
       {label: '근로계약서', value: 'EMPLOYEE_AGREEMENT'},

--- a/src/features/employee/views/EmployeeListView.vue
+++ b/src/features/employee/views/EmployeeListView.vue
@@ -59,13 +59,14 @@ const baseFilterOptions = computed(() => [
     key: 'sortBy',
     type: 'select',
     label: '정렬 기준',
+    icon: 'fa-filter',
     options: [{label: '사번', value: null}, {label: '입사일', value: 'JOIN_DATE'}, {label: '직위', value: 'POSITION'}]
   },
   {
     key: 'order',
     type: 'select',
     label: '정렬',
-    icon: 'fa-filter',
+    icon: 'fa-sort',
     options: [{label: '오름차순', value: 'ASC'}, {label: '내림차순', value: 'DESC'}]
   }
 ]);

--- a/src/features/mypage/views/MyContractsView.vue
+++ b/src/features/mypage/views/MyContractsView.vue
@@ -25,7 +25,7 @@ const columns = [
       }
     }
   },
-  {key: 'salary', label: '연봉', format: val => val == null? '-' : val},
+  {key: 'salary', label: '연봉', format: val => val == null ? '-' : Math.round(val).toLocaleString() + "원"},
   {key: 'createdAt', label: '등록일', format: val => val.split('T')[0]},
 ];
 
@@ -36,7 +36,7 @@ const rowActions = [
 // 필터 정의
 const filterOptions = computed(() => [
   /*{
-    key: 'order', type: 'select', label: '정렬 (등록일)', icon: 'fa-filter', options: [
+    key: 'order', type: 'select', label: '정렬 (등록일)', icon: 'fa-sort', options: [
       {label: '오름차순', value: 'ASC'},
       {label: '내림차순', value: 'DESC'}
     ]


### PR DESCRIPTION
closes #000

---
📌 개요

🔨 주요 변경 사항
- 정렬(오름차순/내림차순) 필터 아이콘 다른 곳과 통일 (`fa-filter` -> `fa-sort`)
- 계약서 조회 시 연봉 표시값 변경
  - 정수 단위로 반올림(자료형이 Decimal이기 때문), 콤마로 연결, 마지막에 "원 표시"
    예시: `40000000.1` -> `40,000,000원`

✅ 리뷰 요청 사항

⭐ 관련 이슈
#22