### PR TITLE
feat : 결재 문서 작성 기능 구현

### DIFF
--- a/src/features/approvals/api.js
+++ b/src/features/approvals/api.js
@@ -49,12 +49,22 @@ export function getOcrApi(formData) {
     });
 }
 
-/* 7. 사원의 상사 불러오기 */
+/* 7. 사원의 연차 불러오기 */
+export function getRemainDayOff() {
+    return api.get(`/remaining/dayoff`)
+}
+
+/* 8. 사원의 리프레시 휴가 불러오기 */
+export function getRemainRefresh() {
+    return api.get(`/remaining/refresh`)
+}
+
+/* 9. 사원의 상사 불러오기 */
 export function getEmployeeLeader() {
     return api.get(`/approval/leader`)
 }
 
-/* 8. 결재 문서 승인/반려 */
+/* 10. 결재 문서 승인/반려 */
 export function approveOrReject(approvalConfirmRequest) {
     return api.patch(`/approval/decision`, approvalConfirmRequest);
 }

--- a/src/features/approvals/components/EmployeeModal.vue
+++ b/src/features/approvals/components/EmployeeModal.vue
@@ -6,7 +6,8 @@ import { fetchDepartments, fetchDepartmentInfo } from '@/features/company/api.js
 
 /* 부모에게 받는 속성 */
 const props = defineProps({
-  alreadySelected: { type: Array, default: () => [] }
+  alreadySelected: { type: Array, default: () => [] },
+  disableFirstApproverRemoval: { type: Boolean, default: false }
 })
 
 /* 자식에게 확인, 취소 버튼 전파하기 */
@@ -31,6 +32,11 @@ const selectDepartment = async (deptId) => {
 /* 멤버 가져오기 */
 const clickEvent = (empId) => {
   const exists = selected.value.find(m => m.empId === empId)
+
+  if (props.disableFirstApproverRemoval && selected.value.length > 0 && selected.value[0].empId === empId) {
+    return;
+  }
+
   if (exists) {
     selected.value = selected.value.filter(m => m.empId !== empId)
     return
@@ -86,13 +92,17 @@ onMounted(async () => {
               <p>선택된 결재자가 없습니다.</p>
             </div>
             <ul class="selected-list">
-              <li v-for="emp in selected" :key="emp.empId" class="selected-card">
+              <li v-for="(emp, idx) in selected" :key="emp.empId" class="selected-card">
                 <i class="fas fa-user icon"></i>
                 <div class="info">
                   <div class="name">{{ emp.name }} {{ emp.position }}</div>
                   <div class="dept">{{ emp.deptName || emp.dept || '-' }}</div>
                 </div>
-                <button class="remove-btn" @click="clickEvent(emp.empId)">
+                <button
+                  class="remove-btn"
+                  @click="clickEvent(emp.empId)"
+                  v-if="!(props.disableFirstApproverRemoval && idx === 0)"
+                >
                   <i class="fas fa-times"></i>
                 </button>
               </li>

--- a/src/features/approvals/components/ReceivedApproval.vue
+++ b/src/features/approvals/components/ReceivedApproval.vue
@@ -27,7 +27,7 @@ const selectedTab = ref('ALL');
 const tabItems = [
   { label: '전체', value: 'ALL', icon: 'fa-building' },
   { label: '근태', value: 'ATTENDANCE', icon: 'fa-sitemap' },
-  { label: '영수증', value: 'RECEIPT', icon: 'fa-receipt' },
+  { label: '비용 처리', value: 'RECEIPT', icon: 'fa-receipt' },
   { label: '품의', value: 'PROPOSAL', icon: 'fa-user-tie' },
   { label: '취소', value: 'CANCEL', icon: 'fa-shield-alt' }
 ]
@@ -96,10 +96,10 @@ function generateBaseFilters() {
 }
 
 /* 동적 필터 */
-// 영수증 필터
+// 비용 처리 필터
 const receiptTypeFilter = {
   key: 'receiptType',
-  label: '영수증 종류',
+  label: '비용 처리 종류',
   icon: 'fa-receipt',
   type: 'select',
   options: ['전체', '식비', '출장비', '비품 구입비', '기타']
@@ -150,7 +150,7 @@ const statusTypeMap = {
 // 결재 종류
 const approveTypeMap = {
   'PROPOSAL': '품의',
-  'RECEIPT': '영수증',
+  'RECEIPT': '비용 처리',
   'BUSINESSTRIP': '출장',
   'VACATION': '휴가',
   'REMOTEWORK': '재택 근무',
@@ -191,7 +191,7 @@ function convertApproveType(tab, approveTypeLabel) {
       '휴가': 'VACATION'
     },
     'RECEIPT': {
-      '영수증': 'RECEIPT'
+      '비용 처리': 'RECEIPT'
     },
     'PROPOSAL': {
       '품의': 'PROPOSAL'
@@ -207,7 +207,7 @@ function convertApproveType(tab, approveTypeLabel) {
 }
 
 
-// 영수증 변환
+// 비용 처리 변환
 function convertReceipt(receiptType) {
   const statusMap = {
     '식비': 'MEALEXPENSE',

--- a/src/features/approvals/components/SentApproval.vue
+++ b/src/features/approvals/components/SentApproval.vue
@@ -24,7 +24,7 @@ const selectedTab = ref('ALL');
 const tabItems = [
   { label: '전체', value: 'ALL', icon: 'fa-building' },
   { label: '근태', value: 'ATTENDANCE', icon: 'fa-sitemap' },
-  { label: '영수증', value: 'RECEIPT', icon: 'fa-receipt' },
+  { label: '비용 처리', value: 'RECEIPT', icon: 'fa-receipt' },
   { label: '품의', value: 'PROPOSAL', icon: 'fa-user-tie' },
   { label: '취소', value: 'CANCEL', icon: 'fa-shield-alt' }
 ]
@@ -72,10 +72,10 @@ const baseFilterOptions = [
 ]
 
 /* 동적 필터 */
-// 영수증 필터
+// 비용 처리 필터
 const receiptTypeFilter = {
   key: 'receiptType',
-  label: '영수증 종류',
+  label: '비용 처리 종류',
   icon: 'fa-receipt',
   type: 'select',
   options: ['전체', '식비', '출장비', '비품 구입비', '기타']
@@ -124,7 +124,7 @@ const statusTypeMap = {
 // 결재 종류
 const approveTypeMap = {
   'PROPOSAL': '품의',
-  'RECEIPT': '영수증',
+  'RECEIPT': '비용 처리',
   'BUSINESSTRIP': '출장',
   'VACATION': '휴가',
   'REMOTEWORK': '재택 근무',
@@ -165,7 +165,7 @@ function convertApproveType(tab, approveTypeLabel) {
       '휴가': 'VACATION'
     },
     'RECEIPT': {
-      '영수증': 'RECEIPT'
+      '비용 처리': 'RECEIPT'
     },
     'PROPOSAL': {
       '품의': 'PROPOSAL'
@@ -181,7 +181,7 @@ function convertApproveType(tab, approveTypeLabel) {
 }
 
 
-// 영수증 변환
+// 비용 처리 변환
 function convertReceipt(receiptType) {
   const statusMap = {
     '식비': 'MEALEXPENSE',

--- a/src/features/approvals/components/WriteFormSection.vue
+++ b/src/features/approvals/components/WriteFormSection.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {computed, ref, watch} from 'vue'
+import {computed, onBeforeUnmount, onMounted, ref, watch} from 'vue'
 import OvertimeForm from '@/features/approvals/components/approveType/OvertimeForm.vue'
 import WorkCorrectionForm from '@/features/approvals/components/approveType/WorkCorrectionForm.vue'
 import RemoteWorkForm from '@/features/approvals/components/approveType/RemoteWorkForm.vue'
@@ -10,6 +10,7 @@ import ReceiptForm from '@/features/approvals/components/approveType/ReceiptForm
 
 const selectedFormComponent = ref(WorkCorrectionForm);
 const formData = ref({});
+const isDropdownOpen = ref(false)
 
 const props = defineProps({
   title: String,
@@ -17,6 +18,16 @@ const props = defineProps({
   formData: Object,
   uploadedFiles: Array
 })
+
+const formLabelMap = {
+  WORKCORRECTION: '출퇴근 정정 신청서',
+  OVERTIME: '초과 근무 신청서',
+  REMOTEWORK: '재택 근무 신청서',
+  BUSINESSTRIP: '출장 신청서',
+  VACATION: '휴가 신청서',
+  PROPOSAL: '품의서',
+  RECEIPT: '비용 처리'
+}
 
 const emit = defineEmits([
   'update:title',
@@ -45,6 +56,26 @@ const formMap = {
   RECEIPT: ReceiptForm
 }
 
+function toggleDropdown() {
+  isDropdownOpen.value = !isDropdownOpen.value
+}
+
+function selectFormType(type) {
+  emit('update:approveType', type)
+  selectedFormComponent.value = formMap[type] || null
+  isDropdownOpen.value = false
+}
+
+function handleClickOutside() {
+  isDropdownOpen.value = false
+}
+
+function handleDocumentType(event) {
+  const type = event.target.value;
+  selectedFormComponent.value = formMap[type] || null;
+  emit('update:approveType', type);
+}
+
 watch(
   () => props.approveType,
   (newType) => {
@@ -53,11 +84,25 @@ watch(
   { immediate: true }
 )
 
-function handleDocumentType(event) {
-  const type = event.target.value;
-  selectedFormComponent.value = formMap[type] || null;
-  emit('update:approveType', type);
-}
+/* 폼 변경 시 기존 데이터 초기화 */
+watch(
+  () => props.approveType,
+  (newType) => {
+    selectedFormComponent.value = formMap[newType] || null;
+
+    emit('update:title', ''); // 제목 초기화
+    emit('update:formData', {}); // form 데이터 초기화
+  },
+  { immediate: true }
+)
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
 </script>
 
 <template>
@@ -84,15 +129,25 @@ function handleDocumentType(event) {
           <i class="fas fa-layer-group"></i>결재 종류
         </h3>
         <div class="form-group">
-          <select class="form-select" @change="handleDocumentType">
-            <option value="WORKCORRECTION">출퇴근 정정 신청서</option>
-            <option value="OVERTIME">초과 근무 신청서</option>
-            <option value="REMOTEWORK">재택 근무 신청서</option>
-            <option value="BUSINESSTRIP">출장 신청서</option>
-            <option value="VACATION">휴가 신청서</option>
-            <option value="PROPOSAL">품의서</option>
-            <option value="RECEIPT">영수증</option>
-          </select>
+          <!-- 커스텀 드롭다운 -->
+          <div class="dropdown-wrapper" @click.stop>
+            <button class="dropdown-btn" @click="toggleDropdown">
+              {{ formLabelMap[props.approveType] || '결재 종류를 선택하세요.' }}
+              <i class="fas fa-chevron-down icon"></i>
+            </button>
+
+            <div class="dropdown" v-if="isDropdownOpen">
+              <button
+                v-for="(label, value) in formLabelMap"
+                :key="value"
+                @click="selectFormType(value)"
+                :class="{ active: props.approveType === value }"
+              >
+                {{ label }}
+              </button>
+            </div>
+          </div>
+
         </div>
       </section>
 
@@ -177,4 +232,52 @@ function handleDocumentType(event) {
   color: var(--blue-100);
 }
 
+.dropdown-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.dropdown-btn {
+  width: 100%;
+  padding: 14px 16px;
+  border: 2px solid var(--gray-200);
+  border-radius: 10px;
+  font-size: 0.95rem;
+  background: var(--color-surface);
+  color: var(--gray-800);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
+  width: 100%;
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  margin-top: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.dropdown button {
+  width: 100%;
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  background: none;
+  border: none;
+  color: var(--gray-800);
+  cursor: pointer;
+}
+
+.dropdown button:hover,
+.dropdown button.active {
+  background-color: var(--blue-100);
+  font-weight: 600;
+}
 </style>

--- a/src/features/approvals/components/approveType/BusinessTripForm.vue
+++ b/src/features/approvals/components/approveType/BusinessTripForm.vue
@@ -1,12 +1,16 @@
 <script setup>
-import {computed, onMounted, ref} from 'vue';
+import {computed, onMounted, onBeforeUnmount, ref, watch} from 'vue';
 import {getFileUrl} from "@/features/common/api.js";
+import {generatePresignedUrl} from "@/features/announcement/api.js";
 
 /* 파일과 관련된 변수들 */
 const file = ref(null);
 const signedUrl = ref(null);
 const fileName = ref(null);
 const uploadedFile = ref(null);
+
+/* 드롭다운 관련 변수 */
+const isDropdownOpen = ref(false);
 
 /* 부모에게 전달 받은 값들 */
 const props = defineProps({
@@ -19,13 +23,91 @@ const props = defineProps({
 const typeOptions = [
   { label: '국내 출장', value: 'DOMESTIC' },
   { label: '해외 출장', value: 'INTERNATIONAL' }
+]
 
-];
-
-/* 수정시 날짜 관련 유효성을 체크하는 부분 */
-const isInvalidDateRange = computed(() => {
-  return form.value.startDate && form.value.endDate && form.value.endDate < form.value.startDate;
+/* 비용 format */
+const formattedCost = computed({
+  get() {
+    if (props.formData.cost == null || isNaN(props.formData.cost)) return '';
+    return Number(props.formData.cost).toLocaleString();
+  },
+  set(val) {
+    // 쉼표 제거 후 숫자로 변환
+    const number = Number(val.replaceAll(',', ''));
+    props.formData.cost = isNaN(number) ? 0 : number;
+  }
 });
+
+/* 에러 메세지 변수들 */
+const errors = ref({
+  type: '',
+  place: '',
+  startDate: '',
+  endDate: '',
+  reason: '',
+  cost: ''
+});
+
+/* 에러 유효성 검증 하기 */
+function validateBusinessTripForm() {
+  errors.value = {
+    type: '',
+    place: '',
+    startDate: '',
+    endDate: '',
+    reason: '',
+    cost: ''
+  };
+
+  if (!props.formData.type) {
+    errors.value.type = '※ 출장 유형을 선택하세요.';
+  }
+
+  if (!props.formData.place?.trim()) {
+    errors.value.place = '※ 출장 장소를 입력하세요.';
+  }
+
+  if (!props.formData.startDate) {
+    errors.value.startDate = '※ 시작일을 입력하세요.';
+  }
+
+  if (!props.formData.endDate) {
+    errors.value.endDate = '※ 종료일을 입력하세요.';
+  }
+
+  if (
+    props.formData.startDate &&
+    props.formData.endDate &&
+    props.formData.endDate < props.formData.startDate
+  ) {
+    errors.value.endDate = '※ 종료일은 시작일보다 빠를 수 없습니다.';
+  }
+
+  if (!props.formData.reason?.trim()) {
+    errors.value.reason = '※ 출장 사유를 입력하세요.';
+  }
+
+  if (props.formData.cost < 0) {
+    errors.value.cost = '※ 비용은 0원 이상이어야 합니다.';
+  }
+
+  return Object.values(errors.value).every(e => !e);
+}
+
+watch(
+  () => [
+    props.formData.type,
+    props.formData.place,
+    props.formData.startDate,
+    props.formData.endDate,
+    props.formData.reason,
+    props.formData.cost
+  ],
+  () => {
+    validateBusinessTripForm();
+  },
+  { immediate: true }
+);
 
 /* 파일 url을 가져오기 위한 함수 */
 async function fetchBusinessTripFile() {
@@ -106,7 +188,23 @@ function removeFile() {
   props.formData.file = null;
 }
 
-onMounted(fetchBusinessTripFile);
+/* 바깥 영역 클릭 시 드롭다운이 사라지게 하기 */
+function handleClickOutside() {
+  isDropdownOpen.value = false;
+}
+
+onMounted(() => {
+  fetchBusinessTripFile();
+  document.addEventListener('click', handleClickOutside);
+  validateBusinessTripForm();
+  if (props.formData.cost == null) { // 비용 기본값은 0원으로 설정
+    props.formData.cost = 0;
+  }
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
 </script>
 
 <template>
@@ -115,61 +213,83 @@ onMounted(fetchBusinessTripFile);
 
       <!-- 1. 출장 유형 -->
       <div class="form-group full-width">
-        <label class="form-label required">출장 유형</label>
+        <label class="form-label required">출장 유형<span v-if="!isReadOnly" class="asterisk"> *</span></label>
         <div v-if="isReadOnly" class="readonly-box">
           {{ typeOptions.find(option => option.value === formData.type)?.label || '선택되지 않음' }}
         </div>
-        <select v-else v-model="formData.type" class="form-input" required>
-          <option disabled value="">선택하세요</option>
-          <option v-for="option in typeOptions" :key="option.value" :value="option.value">
-            {{ option.label }}
-          </option>
-        </select>
+        <div v-else class="dropdown-wrapper" @click.stop>
+          <button class="dropdown-btn" @click="formData.typeDropdownOpen = !formData.typeDropdownOpen">
+            {{ typeOptions.find(option => option.value === formData.type)?.label || '출장 유형 선택' }}
+            <i class="fas fa-chevron-down"></i>
+          </button>
+          <div class="dropdown" v-if="formData.typeDropdownOpen">
+            <button
+              v-for="option in typeOptions"
+              :key="option.value"
+              :class="{ active: formData.type === option.value }"
+              @click="formData.type = option.value; formData.typeDropdownOpen = false"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+          <p v-if="errors.type" class="warning-text">{{ errors.type }}</p>
+        </div>
       </div>
 
       <!-- 2. 출장 장소 -->
       <div class="form-group full-width">
-        <label class="form-label required">출장 장소</label>
+        <label class="form-label required">출장 장소<span v-if="!isReadOnly" class="asterisk"> *</span></label>
         <div v-if="isReadOnly" class="readonly-box">
           {{ formData.place || '입력 없음' }}
         </div>
         <input v-else type="text" v-model="formData.place" class="form-input" required />
+        <p v-if="errors.place" class="warning-text">{{ errors.place }}</p>
       </div>
 
       <!-- 3. 출장 기간 -->
       <div class="form-row">
         <div class="form-group">
-          <label class="form-label required">시작일</label>
+          <label class="form-label required">시작일<span v-if="!isReadOnly" class="asterisk"> *</span></label>
           <div v-if="isReadOnly" class="readonly-box">
             {{ formData.startDate || '입력 없음' }}
           </div>
           <input v-else type="date" v-model="formData.startDate" class="form-input" required />
+          <p v-if="errors.startDate" class="warning-text">{{ errors.startDate }}</p>
         </div>
         <div class="form-group">
-          <label class="form-label required">종료일</label>
+          <label class="form-label required">종료일<span v-if="!isReadOnly" class="asterisk"> *</span></label>
           <div v-if="isReadOnly" class="readonly-box">
             {{ formData.endDate || '입력 없음' }}
           </div>
           <input v-else type="date" v-model="formData.endDate" class="form-input" required />
+          <p v-if="errors.endDate" class="warning-text">{{ errors.endDate }}</p>
         </div>
       </div>
 
       <!-- 4. 출장 사유 -->
       <div class="form-group full-width">
-        <label class="form-label required">출장 사유</label>
+        <label class="form-label required">출장 사유<span v-if="!isReadOnly" class="asterisk"> *</span></label>
         <div v-if="isReadOnly" class="readonly-box">
           {{ formData.reason || '입력 없음' }}
         </div>
         <textarea v-else v-model="formData.reason" class="form-textarea" required></textarea>
+        <p v-if="errors.reason" class="warning-text">{{ errors.reason }}</p>
       </div>
 
       <!-- 5. 예상 비용 -->
       <div class="form-group full-width">
-        <label class="form-label required">예상 비용 (원)</label>
+        <label class="form-label required">예상 비용 (원)<span v-if="!isReadOnly" class="asterisk"> *</span></label>
         <div v-if="isReadOnly" class="readonly-box">
-          {{ formData.cost ? formData.cost.toLocaleString() + ' 원' : '입력 없음' }}
+          {{ formData.cost ? formData.cost.toLocaleString() + ' 원' : '0원' }}
         </div>
-        <input v-else type="number" min="0" v-model="formData.cost" class="form-input" required />
+        <input
+          v-else
+          type="text"
+          v-model="formattedCost"
+          class="form-input"
+          required
+        />
+        <p v-if="errors.cost" class="warning-text">{{ errors.cost }}</p>
       </div>
 
       <!-- 6. 첨부 파일 -->
@@ -270,14 +390,6 @@ select.form-input:focus {
   color: var(--blue-100);
 }
 
-.warning-text {
-  color: var(--error-500);
-  font-size: 0.9rem;
-  margin-top: -12px;
-  margin-bottom: 12px;
-  grid-column: 1 / -1;
-}
-
 .readonly-box {
   padding: 14px 16px;
   border: 2px solid var(--gray-200);
@@ -326,5 +438,65 @@ select.form-input:focus {
 
 .file-icon {
   color: var(--blue-100);
+}
+
+.warning-text {
+  margin-top: 5px;
+  color: var(--error-500);
+  font-size: 0.9rem;
+  grid-column: 1 / -1;
+}
+
+.asterisk {
+  color: var(--error);
+  margin-left: 4px;
+}
+
+.dropdown-wrapper {
+  position: relative;
+}
+
+.dropdown-btn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 14px 16px;
+  border: 2px solid var(--gray-200);
+  border-radius: 10px;
+  font-size: 0.95rem;
+  background: var(--color-surface);
+  color: var(--gray-800);
+  cursor: pointer;
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
+  width: 100%;
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  margin-top: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.dropdown button {
+  width: 100%;
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  border: none;
+  background: none;
+  color: var(--gray-800);
+  cursor: pointer;
+}
+
+.dropdown button:hover,
+.dropdown button.active {
+  background-color: var(--blue-100);
+  font-weight: 600;
 }
 </style>

--- a/src/features/approvals/components/approveType/ReceiptForm.vue
+++ b/src/features/approvals/components/approveType/ReceiptForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {onMounted, ref, watchEffect} from "vue";
+import {computed, onBeforeUnmount, onMounted, ref, watch, watchEffect} from "vue";
 import {getFileUrl} from "@/features/common/api.js";
 import {generatePresignedUrl} from "@/features/announcement/api.js";
 import {getOcrApi} from "@/features/approvals/api.js";
@@ -14,14 +14,28 @@ const previewUrl = ref(null); // 미리보기용 url (업로드 시점에 미리
 const isOcrLoading = ref(false);
 
 /* 금액 포맷을 위한 변수 (','를 넣기 위함) */
-const formattedAmount = ref('');
+const formattedAmount = computed({
+  get() {
+    if (props.formData.amount == null || isNaN(props.formData.amount)) return '';
+    return Number(props.formData.amount).toLocaleString();
+  },
+  set(val) {
+    const number = Number(val.replaceAll(',', ''));
+    props.formData.amount = isNaN(number) ? 0 : number;
+  }
+});
 
+/* 드롭다운 관련 변수 */
+const isReceiptTypeDropdownOpen  = ref(false);
+
+/* 부모에게 전달 받은 값 */
 const props = defineProps({
   formData: { type: Object, required: true },
   isReadOnly: { type: Boolean, default: false },
   approveFileDTO: { type: Array, default: () => [] }
 });
 
+/* 영수증 종류 */
 const receiptTypeOptions = [
   { label: '식비', value: 'MEALEXPENSE' },
   { label: '교통비', value: 'TRAVELEXPENSE' },
@@ -29,7 +43,70 @@ const receiptTypeOptions = [
   { label: '기타', value: 'MISCELLANEOUS' }
 ];
 
-/* 영수증 이미지를 가져오는 api */
+/* 영수증 관련 에러 메세지 */
+const errors = ref({
+  receiptType: '',
+  storeName: '',
+  address: '',
+  usedAt: '',
+  amount: '',
+  attachments: ''
+});
+
+/* 비용 처리 유효성 검사 */
+function validateReceiptForm() {
+  errors.value = {
+    receiptType: '',
+    storeName: '',
+    address: '',
+    usedAt: '',
+    amount: '',
+    attachments: ''
+  };
+
+  if (!props.formData.receiptType) {
+    errors.value.receiptType = '※ 비용 처리 유형을 선택하세요.';
+  }
+  if (!props.formData.storeName?.trim()) {
+    errors.value.storeName = '※ 상호명을 입력하세요.';
+  }
+  if (!props.formData.address?.trim()) {
+    errors.value.address = '※ 주소를 입력하세요.';
+  }
+  if (!props.formData.usedAt) {
+    errors.value.usedAt = '※ 사용일을 선택하세요.';
+  }
+  if (
+    props.formData.amount === '' ||
+    props.formData.amount == null ||
+    isNaN(props.formData.amount) ||
+    props.formData.amount < 0
+  ) {
+    errors.value.amount = '※ 금액은 0 이상의 숫자여야 합니다.';
+  }
+  if (!Array.isArray(props.formData.attachments) || props.formData.attachments.length === 0) {
+    errors.value.attachments = '※ 영수증 파일을 업로드하세요.';
+  }
+
+  return Object.values(errors.value).every((e) => !e);
+}
+
+watch(
+  () => [
+    props.formData.receiptType,
+    props.formData.storeName,
+    props.formData.address,
+    props.formData.usedAt,
+    props.formData.amount,
+    props.formData.attachments
+  ],
+  () => {
+    validateReceiptForm();
+  },
+  { immediate: true }
+);
+
+/* 비용 처리 이미지를 가져오는 api */
 async function fetchReceiptImage() {
   if (props.isReadOnly && props.approveFileDTO.length > 0) {
     const file = props.approveFileDTO[0];
@@ -131,7 +208,33 @@ function removeFile() {
   props.formData.file = null;
 }
 
-onMounted(fetchReceiptImage);
+/* 다른 영역을 클릭 시 드롭 다운 없애기 */
+function handleClickOutside() {
+  isReceiptTypeDropdownOpen .value = false;
+}
+
+/* 토글과 관련된 부분 */
+function toggleReceiptTypeDropdown() {
+  isReceiptTypeDropdownOpen.value = !isReceiptTypeDropdownOpen.value;
+}
+
+function closeReceiptTypeDropdown() {
+  isReceiptTypeDropdownOpen.value = false;
+}
+
+function selectReceiptType(value) {
+  props.formData.receiptType = value;
+  isReceiptTypeDropdownOpen.value = false;
+}
+
+onMounted(() => {
+  fetchReceiptImage()
+  document.addEventListener('click', handleClickOutside)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
 </script>
 
 <template>
@@ -161,22 +264,35 @@ onMounted(fetchReceiptImage);
             <i class="fas fa-times remove-icon" @click="removeFile"></i>
           </div>
         </div>
+        <p v-if="errors.attachments && !isReadOnly" class="warning-text">{{ errors.attachments }}</p>
       </div>
 
       <!-- 2. 영수증 내역 -->
       <div class="form-grid">
-        <!-- 2-1. 영수증 유형 -->
+        <!-- 2-1. 영수증  유형 -->
         <div class="form-group full-width">
-          <label class="form-label required">영수증 유형</label>
+          <label class="form-label required">비용 처리 유형</label>
           <div v-if="isReadOnly" class="readonly-box">
             {{ receiptTypeOptions.find(opt => opt.value === formData.receiptType)?.label || '선택되지 않음' }}
           </div>
-          <select v-else v-model="formData.receiptType" class="form-input" required>
-            <option disabled value="">선택하세요</option>
-            <option v-for="option in receiptTypeOptions" :key="option.value" :value="option.value">
-              {{ option.label }}
-            </option>
-          </select>
+          <div v-else class="dropdown-wrapper receipt-dropdown-wrapper" @click.stop>
+            <button class="dropdown-btn" @click="toggleReceiptTypeDropdown">
+              {{ receiptTypeOptions.find(option => option.value === formData.receiptType)?.label || '비용 처리 종류 선택' }}
+              <i class="fas fa-chevron-down"></i>
+            </button>
+            <div class="dropdown" v-if="isReceiptTypeDropdownOpen">
+              <button
+                v-for="option in receiptTypeOptions"
+                :key="option.value"
+                :class="{ active: formData.receiptType === option.value }"
+                @click="selectReceiptType(option.value)"
+              >
+                {{ option.label }}
+              </button>
+            </div>
+          </div>
+          <p v-if="errors.receiptType" class="warning-text">{{ errors.receiptType }}</p>
+
         </div>
 
         <!-- 2-2. 상호명 -->
@@ -184,6 +300,7 @@ onMounted(fetchReceiptImage);
           <label class="form-label required">상호명</label>
           <div v-if="isReadOnly" class="readonly-box">{{ formData.storeName || '입력 없음' }}</div>
           <input v-else v-model="formData.storeName" type="text" class="form-input" required />
+          <p v-if="errors.storeName" class="warning-text">{{ errors.storeName }}</p>
         </div>
 
         <!-- 2-3. 주소 -->
@@ -191,6 +308,7 @@ onMounted(fetchReceiptImage);
           <label class="form-label required">주소</label>
           <div v-if="isReadOnly" class="readonly-box">{{ formData.address || '입력 없음' }}</div>
           <input v-else v-model="formData.address" type="text" class="form-input" required />
+          <p v-if="errors.address" class="warning-text">{{ errors.address }}</p>
         </div>
 
         <!-- 2-4. 사용일 -->
@@ -198,6 +316,7 @@ onMounted(fetchReceiptImage);
           <label class="form-label required">사용일</label>
           <div v-if="isReadOnly" class="readonly-box">{{ formData.usedAt || '입력 없음' }}</div>
           <input v-else v-model="formData.usedAt" type="date" class="form-input" required />
+          <p v-if="errors.usedAt" class="warning-text">{{ errors.usedAt }}</p>
         </div>
 
         <!-- 2-5. 금액 -->
@@ -206,7 +325,8 @@ onMounted(fetchReceiptImage);
           <div v-if="isReadOnly" class="readonly-box">
             {{ formData.amount ? formData.amount.toLocaleString() + ' 원' : '입력 없음' }}
           </div>
-          <input v-else v-model="formData.amount" type="number" min="0" class="form-input" required />
+          <input v-else v-model="formattedAmount" type="text" class="form-input" required />
+          <p v-if="errors.amount" class="warning-text">{{ errors.amount }}</p>
         </div>
       </div>
     </div>
@@ -367,5 +487,65 @@ select.form-input:focus {
   to {
     transform: rotate(360deg);
   }
+}
+
+.warning-text {
+  margin-top: 5px;
+  color: var(--error-500);
+  font-size: 0.9rem;
+  grid-column: 1 / -1;
+}
+
+.asterisk {
+  color: var(--error);
+  margin-left: 4px;
+}
+
+.dropdown-wrapper {
+  position: relative;
+}
+
+.dropdown-btn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 14px 16px;
+  border: 2px solid var(--gray-200);
+  border-radius: 10px;
+  font-size: 0.95rem;
+  background: var(--color-surface);
+  color: var(--gray-800);
+  cursor: pointer;
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
+  width: 100%;
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  margin-top: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.dropdown button {
+  width: 100%;
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  border: none;
+  background: none;
+  color: var(--gray-800);
+  cursor: pointer;
+}
+
+.dropdown button:hover,
+.dropdown button.active {
+  background-color: var(--blue-100);
+  font-weight: 600;
 }
 </style>

--- a/src/features/approvals/components/approveType/RemoteWorkForm.vue
+++ b/src/features/approvals/components/approveType/RemoteWorkForm.vue
@@ -1,18 +1,52 @@
 <script setup>
-import { computed } from 'vue';
+import {computed, onMounted, ref, watch} from 'vue';
 
 const props = defineProps({
   formData: { type: Object, required: true },
   isReadOnly: { type: Boolean, default: false }
 });
 
-const isInvalidDateRange = computed(() => {
-  return (
+/* 유효성 검사 메세지 */
+const errors = ref({
+  startDate: '',
+  endDate: '',
+});
+
+/* 유효성 검사 함수 */
+function validateForm() {
+  errors.value = {
+    startDate: '',
+    endDate: '',
+  };
+
+  if (!props.formData.startDate) {
+    errors.value.startDate = '※ 시작일은 필수입니다.';
+  }
+
+  if (!props.formData.endDate) {
+    errors.value.endDate = '※ 종료일은 필수입니다.';
+  }
+
+  if (
     props.formData.startDate &&
     props.formData.endDate &&
     props.formData.endDate < props.formData.startDate
-  );
-});
+  ) {
+    errors.value.endDate = '종료일은 시작일보다 빠를 수 없습니다.';
+  }
+
+  return Object.values(errors.value).every((e) => !e);
+}
+
+watch(
+  () => [props.formData.startDate, props.formData.endDate, props.formData.reason],
+  () => {
+    validateForm();
+  },
+  { immediate: true }
+);
+
+onMounted(validateForm);
 </script>
 
 <template>
@@ -21,7 +55,7 @@ const isInvalidDateRange = computed(() => {
       <!-- 재택 근무 기간 -->
       <div class="form-row">
         <div class="form-group">
-          <label class="form-label required">시작일</label>
+          <label class="form-label required">시작일<span v-if="!isReadOnly" class="asterisk"> *</span></label>
           <div v-if="isReadOnly" class="readonly-box">
             {{ formData.startDate || '입력 없음' }}
           </div>
@@ -32,10 +66,11 @@ const isInvalidDateRange = computed(() => {
             class="form-input"
             required
           />
+          <p v-if="errors.startDate" class="warning-text">{{ errors.startDate }}</p>
         </div>
 
         <div class="form-group">
-          <label class="form-label required">종료일</label>
+          <label class="form-label required">종료일<span v-if="!isReadOnly" class="asterisk"> *</span></label>
           <div v-if="isReadOnly" class="readonly-box">
             {{ formData.endDate || '입력 없음' }}
           </div>
@@ -46,13 +81,9 @@ const isInvalidDateRange = computed(() => {
             class="form-input"
             required
           />
+          <p v-if="errors.endDate" class="warning-text">{{ errors.endDate }}</p>
         </div>
       </div>
-
-      <!-- 날짜 유효성 메시지 -->
-      <p v-if="isInvalidDateRange && !isReadOnly" class="warning-text">
-        ※ 종료일은 시작일보다 빠를 수 없습니다.
-      </p>
 
       <!-- 사유 -->
       <div class="form-group full-width">
@@ -128,11 +159,15 @@ const isInvalidDateRange = computed(() => {
 }
 
 .warning-text {
+  margin-top: 5px;
   color: var(--error-500);
   font-size: 0.9rem;
-  margin-top: -12px;
-  margin-bottom: 12px;
   grid-column: 1 / -1;
+}
+
+.asterisk {
+  color: var(--error);
+  margin-left: 4px;
 }
 
 .readonly-box {

--- a/src/features/approvals/components/approveType/VacationForm.vue
+++ b/src/features/approvals/components/approveType/VacationForm.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref, watch } from 'vue';
 import { getFileUrl } from "@/features/common/api.js";
 import { generatePresignedUrl } from "@/features/announcement/api.js";
+import { getRemainDayOff, getRemainRefresh } from "@/features/approvals/api.js";
 
 /* 파일과 관련된 변수들 */
 const file = ref(null);
@@ -18,50 +19,146 @@ const props = defineProps({
 
 /* 휴가 종류 매핑하기 위한 부분 */
 const vacationTypeOptions = [
-  { label: '기타 유급휴가', value: 1 },
-  { label: '기타 무급휴가', value: 2 },
-  { label: '연차', value: 3 },
-  { label: '오전 반차', value: 4 },
-  { label: '오후 반차', value: 5 },
-  { label: '리프레시 휴가', value: 6 },
-  { label: '군 소집 훈련', value: 7 },
-  { label: '경조사', value: 8 }
+  { label: '기타 유급휴가', value: 1, enum: 'PAID_ETC' },
+  { label: '기타 무급휴가', value: 2, enum: 'UNPAID_ETC' },
+  { label: '연차', value: 3, enum: 'DAYOFF' },
+  { label: '오전 반차', value: 4, enum: 'AM_HALF_DAYOFF' },
+  { label: '오후 반차', value: 5, enum: 'PM_HALF_DAYOFF' },
+  { label: '리프레시 휴가', value: 6, enum: 'REFRESH' },
+  { label: '군 소집 훈련', value: 7, enum: 'MILITARY_TRAINING' },
+  { label: '경조사', value: 8, enum: 'LIFE_EVENT' }
 ];
 
 /* 반차인 경우 - 오전 반차, 오후 반차 */
-const isHalfDay = computed(() =>
-  props.formData.vacationType === 'AM_HALF_DAYOFF' ||
-  props.formData.vacationType === 'PM_HALF_DAYOFF'
-);
+const isHalfDay = computed(() => {
+  const typeId = props.formData.vacationTypeId;
+
+  // 오전 반차: 4, 오후 반차: 5
+  return typeId === 4 || typeId === 5;
+});
 
 /* 오전 반차와 오후 반차 각각 시간 표시하기 */
 const halfDayTimeRange = computed(() => {
-  if (props.formData.vacationType === 'AM_HALF_DAYOFF') return '09:00 ~ 13:00';
-  if (props.formData.vacationType === 'PM_HALF_DAYOFF') return '14:00 ~ 18:00';
+  const type = props.formData.vacationType;
+  const typeId = props.formData.vacationTypeId;
+
+  if (type === 'AM_HALF_DAYOFF' || typeId === 4) return '09:00 ~ 13:30';
+  if (type === 'PM_HALF_DAYOFF' || typeId === 5) return '13:30 ~ 18:00';
   return '';
 });
 
-/* 시간 검사 : 끝나는 시간이 시작 시간보다 빠르면 안됨 */
-const isInvalidDateRange = computed(() => {
-  return !isHalfDay.value &&
-    props.formData.startDate &&
+/* 에러 메세지*/
+const vacationTypeError = ref(null);
+const startDateError = ref(null);
+const endDateError = ref(null);
+
+/* vacationTypeId 감시 */
+watch(() => props.formData.vacationTypeId, (newVal) => {
+  vacationTypeError.value = newVal ? '' : '※ 휴가 유형을 선택해주세요.';
+}, { immediate: true });
+
+/* startDate 감시 */
+watch(() => props.formData.startDate, (newVal) => {
+  startDateError.value = newVal ? '' : '※ 시작일을 입력해주세요.';
+
+  // 시작일 변경 시 종료일도 검사 (범위 검증)
+  if (
+    newVal &&
     props.formData.endDate &&
-    props.formData.endDate < props.formData.startDate;
+    props.formData.endDate < newVal
+  ) {
+    endDateError.value = '※ 종료일은 시작일보다 빠를 수 없습니다.';
+  } else if (props.formData.endDate) {
+    endDateError.value = '';
+  }
+}, { immediate: true });
+
+/* endDate 검사 */
+watch(() => props.formData.endDate, (newVal) => {
+  if (!newVal) {
+    endDateError.value = '※ 종료일을 입력해주세요.';
+  } else if (
+    props.formData.startDate &&
+    newVal < props.formData.startDate
+  ) {
+    endDateError.value = '※ 종료일은 시작일보다 빠를 수 없습니다.';
+  } else {
+    endDateError.value = '';
+  }
+}, { immediate: true });
+
+/* 반차인 경우에는 시작 날짜와 끝나는 날짜가 같을 수 있게 설정 */
+watch(
+  () => props.formData.startDate,
+  (newStart) => {
+    if (isHalfDay.value && newStart) {
+      props.formData.endDate = newStart;
+    }
+  }
+);
+
+/* 잔여 연차와 리프레시 휴가 변수 */
+const remainDayOff = ref(null);
+const remainRefresh = ref(null);
+
+const requestedDays = computed(() => {
+  if (isHalfDay.value) return 0.5;
+
+  const { startDate, endDate } = props.formData;
+  if (!startDate || !endDate) return 0;
+
+  return countWeekdays(startDate, endDate);
 });
 
-/* 만약 반차인 경우에는 시작 날짜와 끝나는 날짜가 같으므로 이 부분 처리하기 */
-watch(() => props.formData.vacationType, (newType) => {
-  if (newType === 'AM_HALF_DAYOFF' || newType === 'PM_HALF_DAYOFF') {
-    props.formData.endDate = props.formData.startDate;
+/* 휴가 수 제한 하기 */
+const exceedVacationLimit = computed(() => {
+  const typeId = props.formData.vacationTypeId;
+  if (!typeId) return false;
+
+  const selected = vacationTypeOptions.find(o => o.value === typeId);
+  if (!selected) return false;
+
+  const typeEnum = selected.enum;
+
+  if (typeEnum === 'DAYOFF' && requestedDays.value > remainDayOff.value.replace('일', '') * 1) {
+    return '※ 신청 일수가 잔여 연차보다 많습니다.';
   }
+
+  if (typeEnum === 'REFRESH' && requestedDays.value > remainRefresh.value.replace('일', '') * 1) {
+    return '※ 신청 일수가 잔여 리프레시 휴가보다 많습니다.';
+  }
+
+  return '';
 });
 
-/* 연반차는 시작과 끝나는 날짜가 같음 */
-watch(() => props.formData.startDate, (newDate) => {
-  if (isHalfDay.value) {
-    props.formData.endDate = newDate;
+/* 평일 수 계산 함수 */
+function countWeekdays(start, end) {
+  let count = 0;
+  const current = new Date(start);
+
+  while (current <= new Date(end)) {
+    const day = current.getDay();
+    if (day !== 0 && day !== 6) count++;
+    current.setDate(current.getDate() + 1);
   }
-});
+
+  return count;
+}
+
+/* 잔여 연차와 잔여 리프레시 휴가를 가져오기 */
+async function fetchRemainVacation() {
+  try {
+    const dayOff = await getRemainDayOff();
+    const refresh = await getRemainRefresh();
+
+    console.log(dayOff.data.data);
+    remainDayOff.value = dayOff.data.data.remainingDayoffHours/8 + '일';
+    remainRefresh.value = refresh.data.data.remainingRefreshDays +'일';
+
+  } catch (err) {
+    console.error("잔여 휴가 불러오기 실패:", err);
+  }
+}
 
 /* 파일 url을 가져오기 위한 함수 */
 async function fetchVacationFile() {
@@ -143,36 +240,81 @@ function removeFile() {
   props.formData.file = null;
 }
 
-onMounted(fetchVacationFile);
+/* 드롭 다운 관련 요소 */
+const showVacationDropdown = ref(false);
+
+function toggleVacationDropdown() {
+  showVacationDropdown.value = !showVacationDropdown.value;
+}
+
+function selectVacationType(option) {
+  props.formData.vacationTypeId = option.value;
+  showVacationDropdown.value = false;
+}
+
+const selectedVacationLabel = computed(() => {
+  return vacationTypeOptions.find(opt => opt.value === props.formData.vacationTypeId)?.label || '휴가 종류를 선택하세요.';
+});
+
+onMounted(() => {
+  fetchVacationFile();
+  fetchRemainVacation();
+});
 </script>
 
 <template>
   <div class="form-section">
+    <!-- 1. 남은 연차, 리프레시 휴가 -->
     <div class="form-grid">
-
-      <!-- 1. 휴가 유형 -->
-      <div class="form-group full-width">
-        <label class="form-label required">휴가 유형</label>
-        <div v-if="isReadOnly" class="readonly-box">
-          {{ vacationTypeOptions.find(o => o.value === formData.vacationType)?.label || '선택되지 않음' }}
+      <div v-if="!isReadOnly" class="form-row">
+        <div class="form-group">
+          <label class="form-label required">잔여 연차 </label>
+          <div class="readonly-box">{{ remainDayOff }}</div>
         </div>
-        <select v-else v-model="formData.vacationTypeId" class="form-input" required>
-          <option disabled value="">휴가 종류를 선택하세요.</option>
-          <option v-for="option in vacationTypeOptions" :key="option.value" :value="option.value">
-            {{ option.label }}
-          </option>
-        </select>
+
+        <div class="form-group">
+          <label class="form-label required">잔여 리프레시 휴가</label>
+          <div class="readonly-box">{{ remainRefresh }}</div>
+        </div>
       </div>
 
-      <!-- 2. 휴가 날짜 -->
+      <!-- 2. 휴가 유형 -->
+      <div class="form-group full-width">
+        <label class="form-label required">휴가 유형<span v-if="!isReadOnly"  class="asterisk"> *</span></label>
+        <div v-if="isReadOnly" class="readonly-box">
+          {{ vacationTypeOptions.find(o => o.enum === formData.vacationType)?.label || '선택되지 않음' }}
+        </div>
+        <div v-else class="dropdown-wrapper">
+          <button class="dropdown-btn" @click="toggleVacationDropdown">
+            {{ selectedVacationLabel }}
+            <i class="fas fa-chevron-down icon"></i>
+          </button>
+          <div class="dropdown" v-if="showVacationDropdown">
+            <button
+              v-for="option in vacationTypeOptions"
+              :key="option.value"
+              :class="{ active: formData.vacationTypeId === option.value }"
+              @click="selectVacationType(option)"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+        </div>
+
+        <p v-if="!isReadOnly && vacationTypeError" class="warning-text">{{ vacationTypeError }}</p>
+      </div>
+
+      <!-- 3. 휴가 날짜 -->
       <div class="form-row">
         <div class="form-group">
-          <label class="form-label required">시작일</label>
+          <label class="form-label required">시작일<span v-if="!isReadOnly"  class="asterisk"> *</span></label>
           <div v-if="isReadOnly" class="readonly-box">{{ formData.startDate || '입력 없음' }}</div>
           <input v-else type="date" v-model="formData.startDate" class="form-input" required />
+         <p v-if="!isReadOnly && startDateError" class="warning-text">{{ startDateError }}</p>
         </div>
+
         <div class="form-group">
-          <label class="form-label required">종료일</label>
+          <label class="form-label required">종료일<span v-if="!isReadOnly"  class="asterisk"> *</span></label>
           <div v-if="isReadOnly" class="readonly-box">{{ formData.endDate || '입력 없음' }}</div>
           <input
             v-else
@@ -183,26 +325,24 @@ onMounted(fetchVacationFile);
             :disabled="isHalfDay"
             required
           />
+          <p v-if="!isReadOnly && endDateError" class="warning-text">{{ endDateError }}</p>
         </div>
       </div>
 
-      <!-- 반차 시간대 -->
-      <p v-if="isHalfDay && !isReadOnly" class="info-text">
+      <p v-if="!isReadOnly && exceedVacationLimit" class="warning-text">{{ exceedVacationLimit }}</p>
+
+      <p v-if="halfDayTimeRange" class="info-text">
         ※ 반차 시간대: {{ halfDayTimeRange }}
       </p>
 
-      <!-- 날짜 오류 -->
-      <p v-if="isInvalidDateRange && !isReadOnly" class="warning-text">
-        ※ 종료일은 시작일보다 빠를 수 없습니다.
-      </p>
-
-      <!-- 3. 휴가 사유 -->
+      <!-- 4. 휴가 사유 -->
       <div class="form-group full-width">
         <label class="form-label required">휴가 사유</label>
         <div v-if="isReadOnly" class="readonly-box">{{ formData.reason || '입력 없음' }}</div>
         <textarea v-else v-model="formData.reason" class="form-textarea" required />
       </div>
 
+      <!-- 5. 첨부파일 -->
       <div class="form-group full-width">
         <label class="form-label">첨부파일</label>
         <div class="readonly-box" v-if="file && signedUrl&&isReadOnly">
@@ -283,10 +423,15 @@ select.form-input {
   min-height: 100px;
 }
 
+.form-input::placeholder {
+  color: #9ca3af;
+}
+
 .form-input:focus,
-.form-textarea:focus,
-select.form-input:focus {
+.form-textarea:focus {
   outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 4px rgba(102, 126, 234, 0.1);
   transform: translateY(-1px);
 }
 
@@ -313,20 +458,19 @@ select.form-input:focus {
   color: var(--blue-100);
 }
 
-.warning-text {
-  color: var(--error-500);
+.warning-text,.info-text {
   font-size: 0.9rem;
-  margin-top: -12px;
-  margin-bottom: 12px;
   grid-column: 1 / -1;
 }
 
+.warning-text {
+  margin-top: 5px;
+  color: var(--error-500);
+}
+
 .info-text {
-  color: var(--blue-300);
-  font-size: 0.9rem;
   margin-top: -12px;
-  margin-bottom: 12px;
-  grid-column: 1 / -1;
+  color: var(--blue-300);
 }
 
 .upload-wrapper {
@@ -368,4 +512,54 @@ select.form-input:focus {
 .file-icon {
   color: var(--blue-100);
 }
+
+.asterisk {
+  color: var(--error);
+  margin-left: 4px;
+}
+
+.dropdown-wrapper {
+  position: relative;
+}
+.dropdown-btn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 14px 16px;
+  border: 2px solid var(--gray-200);
+  border-radius: 10px;
+  font-size: 0.95rem;
+  background: var(--color-surface);
+  color: var(--gray-800);
+  cursor: pointer;
+}
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
+  width: 100%;
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  margin-top: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+.dropdown button {
+  width: 100%;
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  border: none;
+  background: none;
+  color: var(--gray-800);
+  cursor: pointer;
+}
+.dropdown button:hover,
+.dropdown button.active {
+  background-color: var(--blue-100);
+  font-weight: 600;
+}
+
 </style>

--- a/src/features/approvals/components/approveType/WorkCorrectionForm.vue
+++ b/src/features/approvals/components/approveType/WorkCorrectionForm.vue
@@ -1,78 +1,238 @@
 <script setup>
+import { getMyWorks } from "@/features/works/api.js";
+import {computed, onBeforeUnmount, onMounted, ref, watch} from "vue";
+
+/* 일 목록 가져오는 변수 */
+const workList = ref([]);
+const selectedWorkId = ref("");
+
+/* 드롭다운 상태 */
+const showWorkDropdown = ref(false);
+const dropdownRef = ref(null); // 드롭다운 감지용
+
+/* 유효성 에러 메시지 */
+const errors = ref({
+  workId: '',
+  time: '',
+  reason: ''
+});
+
+/* 변경되는 시간 */
+const startTime = ref('');
+const endTime = ref('');
+const fixedDate = ref(''); // YYYY-MM-DD 형태
+
+/* 오늘부터 1주일 전까지만 조회하게 설정 */
+const today = new Date();
+const oneWeekAgo = new Date();
+oneWeekAgo.setDate(today.getDate() - 7);
+
+/* 부모에게서 받아온 값*/
 const props = defineProps({
   formData: { type: Object, required: true },
   isReadOnly: { type: Boolean, default: false }
+})
+
+/* 선택된 근무 항목의 라벨 */
+const selectedWorkLabel = computed(() => {
+  const selected = workList.value.find(w => w.workId === selectedWorkId.value);
+  return selected ? `${selected.startAt.replace('T', ' ')} ~ ${selected.endAt.replace('T', ' ')}` : '기존 출근 정보를 선택하세요.';
+});
+
+/* 날짜를 조회할 때 'T' 제외 하기 */
+function formatDate(date) {
+  return date.toISOString().split('T')[0];
+}
+
+/* 기존 근무 선택 변경 시 처리*/
+watch(selectedWorkId, (id) => {
+  if (!id) return;
+
+  const selectedWork = workList.value.find(w => w.workId === id);
+  if (selectedWork) {
+    const date = selectedWork.startAt.split('T')[0];
+    fixedDate.value = date;
+    updateBeforeTimes(selectedWork);
+  }
+});
+
+// 날짜 + 시간 합쳐서 formData 반영
+watch([startTime, endTime, fixedDate], () => {
+  if (startTime.value && fixedDate.value)
+    props.formData.afterStartAt = `${fixedDate.value}T${startTime.value}`;
+
+  if (endTime.value && fixedDate.value)
+    props.formData.afterEndAt = `${fixedDate.value}T${endTime.value}`;
+});
+
+/* 유효성 검사 */
+watch([startTime, endTime, selectedWorkId, () => props.formData.reason], () => {
+  validateForm();
+});
+
+function validateForm() {
+  errors.value = { workId: '', time: '', reason: '' };
+
+  if (!startTime.value || !endTime.value) {
+    errors.value.time = '※ 출근 시간과 퇴근 시간을 모두 입력해주세요.';
+  } else if (startTime.value >= endTime.value) {
+    errors.value.time = '※ 퇴근 시간은 출근 시간보다 늦어야 합니다.';
+  }
+
+  if (!props.formData.reason?.trim()) {
+    errors.value.reason = '※ 출퇴근 정정 사유를 입력해주세요.';
+  }
+
+  return !errors.value.workId && !errors.value.time && !errors.value.reason;
+}
+
+/* 드롭다운에서 바깥 영역을 클릭 시 닫힐 수 있게 설정 */
+function handleClickOutside(event) {
+  if (dropdownRef.value && !dropdownRef.value.contains(event.target)) {
+    showWorkDropdown.value = false;
+  }
+}
+
+/* 사원의 근무 목록 불러오기 */
+async function fetchMyWorks() {
+  try {
+
+    const payload = {
+      rangeStartDate: formatDate(oneWeekAgo),
+      rangeEndDate: formatDate(today)
+    };
+
+    const res = await getMyWorks(payload);
+    const works = res || [];
+
+    workList.value = res.works;
+
+    if (works.length > 0) {
+      updateBeforeTimes(works[0])
+    }
+  } catch (e) {
+    console.error('근무 정보를 불러오는데 오류가 발생했습니다.', e)
+  }
+}
+
+/* 이전 시간을 업데이트 하는 로직 */
+function updateBeforeTimes(work) {
+  props.formData.workId = selectedWorkId.value;
+  props.formData.beforeStartAt = work.startAt;
+  props.formData.beforeEndAt = work.endAt;
+}
+
+/* 드롭다운 내부에서 선택 시 처리 */
+function selectWork(workId) {
+  selectedWorkId.value = workId;
+  showWorkDropdown.value = false;
+}
+
+/* 마운트 되는 시점에 가져오기 */
+onMounted(() => {
+  fetchMyWorks();
+  validateForm();
+  document.addEventListener("click", handleClickOutside);
+});
+
+onBeforeUnmount(() => {
+  document.removeEventListener("click", handleClickOutside);
 });
 </script>
 
 <template>
   <div class="form-section">
     <div class="form-grid">
-      <!-- 기존 출퇴근 -->
-      <div class="form-row">
-        <div class="form-group">
-          <label class="form-label required">기존 출근 일시</label>
-          <div v-if="isReadOnly" class="readonly-box">
-            {{ formData.beforeStartAt || '입력 없음' }}
+      <!-- 1. 기존 출퇴근 -->
+      <div v-if="!isReadOnly" class="form-row">
+        <div class="form-group full-width">
+          <label class="form-label required">기존 근무<span class="asterisk"> *</span></label>
+          <div class="dropdown-wrapper" ref="dropdownRef">
+            <button class="dropdown-btn" @click="showWorkDropdown = !showWorkDropdown">
+              {{ selectedWorkLabel }}
+              <i class="fas fa-chevron-down icon"></i>
+            </button>
+            <div class="dropdown" v-if="showWorkDropdown">
+              <button
+                v-for="work in workList"
+                :key="work.workId"
+                @click="selectWork(work.workId)"
+                :class="{ active: selectedWorkId === work.workId }"
+              >
+                {{ work.startAt.replace('T', ' ') }} ~ {{ work.endAt.replace('T', ' ') }}
+              </button>
+            </div>
           </div>
-          <input
-            v-else
-            v-model="formData.beforeStartAt"
-            type="datetime-local"
-            class="form-input"
-            required
-          />
+        </div>
+        <p class="info-text">※ 7일 이내 출퇴근 기록만 수정할 수 있습니다. </p>
+      </div>
+      <div v-else class="form-row">
+        <div class="form-group">
+          <label class="form-label required">기존 출근 일시<span v-if="!isReadOnly"  class="asterisk"> *</span></label>
+          <div class="readonly-box">
+            {{ formData.beforeStartAt.replace('T', ' ') || '입력 없음' }}
+          </div>
         </div>
 
         <div class="form-group">
-          <label class="form-label required">기존 퇴근 일시</label>
-          <div v-if="isReadOnly" class="readonly-box">
-            {{ formData.beforeEndAt || '입력 없음' }}
+          <label class="form-label required">기존 퇴근 일시<span v-if="!isReadOnly"  class="asterisk"> *</span></label>
+          <div class="readonly-box">
+            {{ formData.afterEndAt.replace('T', ' ') || '입력 없음' }}
           </div>
-          <input
-            v-else
-            v-model="formData.beforeEndAt"
-            type="datetime-local"
-            class="form-input"
-            required
-          />
         </div>
       </div>
 
-      <!-- 수정 출퇴근 -->
+      <!-- 2. 수정 출근 / 퇴근 일시 -->
       <div class="form-row">
+        <!-- 수정 출근 -->
         <div class="form-group">
-          <label class="form-label required">수정 출근 일시</label>
+          <label class="form-label required">수정 출근 일시<span v-if="!isReadOnly"  class="asterisk"> *</span></label>
           <div v-if="isReadOnly" class="readonly-box">
             {{ formData.afterStartAt || '입력 없음' }}
           </div>
-          <input
-            v-else
-            v-model="formData.afterStartAt"
-            type="datetime-local"
-            class="form-input"
-            required
-          />
+          <div v-else class="time-picker-wrapper">
+            <input
+              class="form-input"
+              type="date"
+              :value="fixedDate"
+              disabled
+            />
+            <input
+              class="form-input"
+              type="time"
+              v-model="startTime"
+              required
+            />
+          </div>
+          <p v-if="errors.time" class="warning-text">{{ errors.time }}</p>
         </div>
 
+        <!-- 수정 퇴근 -->
         <div class="form-group">
-          <label class="form-label required">수정 퇴근 일시</label>
-          <div v-if="isReadOnly" class="readonly-box">
+          <label class="form-label required">수정 퇴근 일시<span v-if="!isReadOnly"  class="asterisk"> *</span></label>
+          <div v-if="isReadOnly" class="reado nly-box">
             {{ formData.afterEndAt || '입력 없음' }}
           </div>
-          <input
-            v-else
-            v-model="formData.afterEndAt"
-            type="datetime-local"
-            class="form-input"
-            required
-          />
+          <div v-else class="time-picker-wrapper">
+            <input
+              class="form-input"
+              type="date"
+              :value="fixedDate"
+              disabled
+            />
+            <input
+              class="form-input"
+              type="time"
+              v-model="endTime"
+              required
+            />
+          </div>
         </div>
       </div>
 
       <!-- 사유 -->
       <div class="form-group full-width">
-        <label class="form-label required">출퇴근 정정 사유</label>
+        <label class="form-label required">출퇴근 정정 사유<span v-if="!isReadOnly"  class="asterisk"> *</span></label>
         <div v-if="isReadOnly" class="readonly-box">
           {{ formData.reason || '입력 없음' }}
         </div>
@@ -82,6 +242,8 @@ const props = defineProps({
           class="form-textarea"
           required
         ></textarea>
+        <p v-if="errors.reason" class="warning-text">{{ errors.reason }}</p>
+
       </div>
     </div>
   </div>
@@ -151,5 +313,83 @@ const props = defineProps({
   color: var(--gray-800);
   white-space: pre-wrap;
   min-height: 44px;
+}
+
+.warning-text,.info-text {
+  font-size: 0.9rem;
+  grid-column: 1 / -1;
+}
+
+.warning-text {
+  margin-top: 5px;
+  color: var(--error-500);
+}
+
+.info-text {
+  margin-top: -12px;
+  color: var(--blue-300);
+}
+
+.time-picker-wrapper {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.time-picker-wrapper .form-input[type="date"],
+.time-picker-wrapper .form-input[type="time"] {
+  max-width: 140px;
+  width: 100%;
+  min-width: 0;
+}
+
+.asterisk {
+  color: var(--error);
+  margin-left: 4px;
+}
+
+.dropdown-wrapper {
+  position: relative;
+}
+
+.dropdown-btn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 14px 16px;
+  border: 2px solid var(--gray-200);
+  border-radius: 10px;
+  font-size: 0.95rem;
+  background: var(--color-surface);
+  color: var(--gray-800);
+  cursor: pointer;
+}
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
+  width: 100%;
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: 8px;
+  margin-top: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+.dropdown button {
+  width: 100%;
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 0.95rem;
+  border: none;
+  background: none;
+  color: var(--gray-800);
+  cursor: pointer;
+}
+.dropdown button:hover,
+.dropdown button.active {
+  background-color: var(--blue-100);
+  font-weight: 600;
 }
 </style>

--- a/src/features/approvals/views/ApproveDetailActionView.vue
+++ b/src/features/approvals/views/ApproveDetailActionView.vue
@@ -38,7 +38,7 @@ const approveTypeText = (approveType) => {
     case 'BUSINESSTRIP': return '출장 신청서'
     case 'VACATION': return '휴가 신청서'
     case 'PROPOSAL': return '품의서'
-    case 'RECEIPT': return '영수증'
+    case 'RECEIPT': return '비용 처리'
     case 'CANCEL': return '취소'
   }
 }

--- a/src/features/approvals/views/ApproveEditCreateView.vue
+++ b/src/features/approvals/views/ApproveEditCreateView.vue
@@ -26,7 +26,7 @@ const approveTypeText = (approveType) => {
     case 'BUSINESSTRIP': return '출장 신청서'
     case 'VACATION': return '휴가 신청서'
     case 'PROPOSAL': return '품의서'
-    case 'RECEIPT': return '영수증'
+    case 'RECEIPT': return '비용 처리'
     case 'CANCEL': return '취소'
   }
 }
@@ -40,10 +40,6 @@ function goBack() {
     router.go(-1)
   }
 }
-
-/* 쓸데 없이 넘어가는 vacationType 제거 */
-delete formDetail.value.vacationType;
-
 
 /* 결재 문서 제출하기 */
 async function submitForm() {
@@ -70,11 +66,16 @@ async function submitForm() {
 
   try {
     await submitApproval(request);
-    alert('결재 문서가 성공적으로 제출되었습니다.');
-    await router.push({name: 'ApprovalList'});
+
+    await router.push({
+      name: 'MyApprovalsList',
+      query: { tab: 'sent' }
+    });
+
   } catch (error) {
     console.error(error);
     alert('제출 중 오류가 발생했습니다.');
+
   }
 }
 </script>

--- a/src/features/approvals/views/MyApprovalList.vue
+++ b/src/features/approvals/views/MyApprovalList.vue
@@ -1,20 +1,29 @@
 <script setup>
-import { ref } from 'vue'
-
+import {onMounted, ref} from 'vue'
 import ReceivedApproval from "@/features/approvals/components/ReceivedApproval.vue"
 import SentApproval from "@/features/approvals/components/SentApproval.vue"
 import ApprovalHeader from "@/features/approvals/components/ApprovalHeader.vue";
-import { useRouter } from 'vue-router'
+import {useRoute, useRouter} from 'vue-router'
 
 /* 경로 이동을 의한 부분 */
 const router = useRouter();
+const route = useRoute();
+
 /* 현재 활성화 되어 있는 탭 */
 const currentTab = ref('RECEIVED')
 
 /* 탭 클릭 핸들러 */
 const handleTabClick = (tabLabel) => {
-  currentTab.value = tabLabel === '받은 문서함' ? 'RECEIVED' : 'SENT'
+  currentTab.value = tabLabel === '받은 문서함' ? 'RECEIVED' : 'SENT';
+  router.replace({ query: { tab: currentTab.value === 'SENT' ? 'sent' : 'received' } });
 }
+
+/* 컴포넌트가 마운트될 때 쿼리 파라미터를 확인하여 currentTab을 설정 */
+onMounted(() => {
+  if (route.query.tab === 'sent') {
+    currentTab.value = 'SENT';
+  }
+});
 </script>
 
 <template>


### PR DESCRIPTION
closes #5

---

📌 개요
결재 문서 작성 기능 구현 

🔨 주요 변경 사항
- select가 포함되어 있는 모든 컴포넌트에서 드롭 다운 디자인 수정
- 모든 결재 form에서 유효성 검사 추가 (만족하지 못하면 error 메세지가 뜸)
- 모든 조건에서 영수증 대신 `비용 처리`로 용어 변경 
- 문서 작성 한 뒤에 `보낸 문서함`으로 갈 수 있게 수정 
- 결재선 지정 시 첫번째 결재선에 있는 팀장이 사원 선택 모달에서 사라지지 않게 수정
- 결재에서 필요한 모든 api 연결
  - 사원의 연차 수를 불러오는 api
  - 사원의 리프레시 휴가 수를 불러오는 api 
- 전체적인 디자인 수정 

✅ 리뷰 요청 사항

⭐ 관련 이슈
#5
