### PR TITLE
fix : 결재 문서 관련 오류 및 디자인 수정

### DIFF
--- a/src/components/common/Sidebar.vue
+++ b/src/components/common/Sidebar.vue
@@ -56,7 +56,11 @@
                     v-if="isAllowed(sub)"
                     :to="resolveRoute(sub.hrefs)"
                     class="sidebar-item"
-                    :class="{ active: isActive(resolveRouteList(sub.hrefs)) }"
+                    :class="{
+                      active: sub.activeMatch === 'startsWith'
+                          ? getActiveMatch(sub)
+                          : isActive(resolveRouteList(sub.hrefs))
+                    }"
                 >
                   {{ sub.label }}
                 </router-link>
@@ -190,9 +194,12 @@ const menuItems = [
       {
         label: '전체 결재 내역',
         hrefs: ['/approvals'],
-        requireRole: ['MASTER', 'HR_MANAGER']
+        requireRole: ['MASTER', 'HR_MANAGER'],
+        activeMatch: 'startsWith'
       },
-      { label: '문서함', hrefs: ['/approval/inbox'] }
+      { label: '문서함',
+        hrefs: ['/approval/inbox', '/approval/write'],
+        activeMatch: 'startsWith' }
     ]
   },
   {
@@ -285,6 +292,32 @@ function isActive(hrefs) {
   const list = Array.isArray(hrefs) ? hrefs : [hrefs]
   return list.some(href => currentPath.endsWith(href.replace('../', '/')))
 }
+
+function isActiveStartsWith(hrefs) {
+  const currentPath = route.path
+  const list = Array.isArray(hrefs) ? hrefs : [hrefs]
+  return list.some(href => currentPath.startsWith(href.replace('../', '/')))
+}
+
+function getActiveMatch(item) {
+  // 먼저 현재 라우트 출처를 확인
+  const source = route.state?.source || route.query?.from
+
+  // 출처와 메뉴 라벨 조합으로 분기 처리
+  if (item.label === '전체 결재 내역' && source === 'approvals') {
+    return isActiveStartsWith(['/approval/detail', '/approvals'])
+  }
+
+  if (item.label === '문서함' && source === 'inbox') {
+    return isActiveStartsWith(['/approval/detail', '/approval/inbox', '/approval/write'])
+  }
+
+  // 그 외: activeMatch === 'startsWith' 여부로 처리
+  if (item.activeMatch === 'startsWith') {
+    return isActiveStartsWith(item.hrefs)
+  }
+}
+
 
 function isSubmenuActive(subItems) {
   return subItems.some(item => isAllowed(item) && isActive(resolveRouteList(item.hrefs)))

--- a/src/features/approvals/components/ReceivedApproval.vue
+++ b/src/features/approvals/components/ReceivedApproval.vue
@@ -291,8 +291,11 @@ async function fetchReceivedApprovals() {
 function handleDetailClick(row) {
   router.push({
     name: 'ApprovalDetail',
-    params: { documentId: row.approveId }
-  })}
+    params: { documentId: row.approveId },
+    state: { source: 'inbox' },
+    query: { from: 'inbox',  tab: 'received' }
+  })
+}
 
 /* 페이지와 관련된 부분 */
 watch(currentPage, () => {

--- a/src/features/approvals/components/SentApproval.vue
+++ b/src/features/approvals/components/SentApproval.vue
@@ -263,7 +263,9 @@ async function fetchSentApprovals() {
 function handleDetailClick(row) {
   router.push({
     name: 'ApprovalDetail',
-    params: { documentId: row.approveId }
+    params: { documentId: row.approveId },
+    state: { source: 'inbox' },
+    query: { from: 'inbox',  tab: 'sent' }
   })}
 
 /* 페이지를 위한 부분 */

--- a/src/features/approvals/components/approveType/BusinessTripForm.vue
+++ b/src/features/approvals/components/approveType/BusinessTripForm.vue
@@ -131,16 +131,25 @@ async function fetchBusinessTripFile() {
   }
 }
 
-/* 파일 다운로드 하기 (클릭시 작동) */
-function handleFileClick() {
+async function handleFileClick() {
   if (!signedUrl.value || !file.value) return;
 
-  const link = document.createElement("a");
-  link.href = signedUrl.value;
-  link.download = file.value.originalFileName;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+  try {
+    const response = await fetch(signedUrl.value);
+    const blob = await response.blob();
+
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = file.value;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(url);
+  } catch (err) {
+    console.error("파일 다운로드 실패:", err);
+    alert("파일 다운로드 중 오류가 발생했습니다.");
+  }
 }
 
 /* 파일 업로드 하기 */
@@ -296,12 +305,12 @@ onBeforeUnmount(() => {
       <div class="form-group full-width">
         <label class="form-label">첨부파일</label>
         <div class="readonly-box" v-if="file && signedUrl&&isReadOnly">
-          <span class="file-link" @click="handleFileClick">
+<span class="file-link" @click.stop.prevent="handleFileClick">
             <i class="fas fa-download file-icon"></i>
               {{ fileName }}
           </span>
         </div>
-        <div class="readonly-box" v-if="isReadOnly">첨부파일 없음</div>
+        <div class="readonly-box" v-if="isReadOnly && !file">첨부파일 없음</div>
 
         <div v-if="!isReadOnly" class="upload-wrapper">
           <label class="upload-box">

--- a/src/features/approvals/components/approveType/BusinessTripForm.vue
+++ b/src/features/approvals/components/approveType/BusinessTripForm.vue
@@ -2,12 +2,15 @@
 import {computed, onMounted, onBeforeUnmount, ref, watch} from 'vue';
 import {getFileUrl} from "@/features/common/api.js";
 import {generatePresignedUrl} from "@/features/announcement/api.js";
+import {useToast} from "vue-toastification";
 
 /* 파일과 관련된 변수들 */
 const file = ref(null);
 const signedUrl = ref(null);
 const fileName = ref(null);
 const uploadedFile = ref(null);
+
+const toast = useToast();
 
 /* 드롭다운 관련 변수 */
 const isDropdownOpen = ref(false);
@@ -148,7 +151,7 @@ async function handleFileClick() {
     window.URL.revokeObjectURL(url);
   } catch (err) {
     console.error("파일 다운로드 실패:", err);
-    alert("파일 다운로드 중 오류가 발생했습니다.");
+    toast.error('파일 다운로드 중 에러가 발생했습니다.');
   }
 }
 
@@ -187,7 +190,7 @@ async function handleFileUpload(event) {
 
   } catch (err) {
     console.error("파일 업로드 실패:", err);
-    alert("파일 업로드 중 오류가 발생했습니다.");
+    toast.error("파일 업로드 중 오류가 발생했습니다.");
   }
 }
 

--- a/src/features/approvals/components/approveType/BusinessTripForm.vue
+++ b/src/features/approvals/components/approveType/BusinessTripForm.vue
@@ -114,7 +114,6 @@ async function fetchBusinessTripFile() {
   if (!props.isReadOnly || props.approveFileDTO.length === 0) return;
 
   file.value = props.approveFileDTO[0];
-  console.log(file.value.fileName)
 
   try {
     const resp = await getFileUrl({
@@ -141,7 +140,8 @@ async function handleFileClick() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = file.value;
+    a.download = fileName.value;
+
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);

--- a/src/features/approvals/components/approveType/ProposalForm.vue
+++ b/src/features/approvals/components/approveType/ProposalForm.vue
@@ -45,15 +45,27 @@ async function fetchProposalFile() {
 }
 
 /* 파일 다운하기  */
-function handleFileClick() {
+async function handleFileClick() {
   if (!signedUrl.value || !file.value) return;
 
-  const link = document.createElement("a");
-  link.href = signedUrl.value;
-  link.download = file.value.originalFileName;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+  try {
+    const response = await fetch(signedUrl.value);
+    const blob = await response.blob();
+
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+
+    a.href = url;
+    a.download = file.value;
+
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(url);
+  } catch (err) {
+    console.error("파일 다운로드 실패:", err);
+    alert("파일 다운로드 중 오류가 발생했습니다.");
+  }
 }
 
 /* 파일 업로드 하기 */
@@ -137,13 +149,13 @@ onMounted(() => {
       <!-- 1. 첨부파일 -->
       <div class="form-group full-width">
         <label class="form-label">첨부파일</label>
-        <div class="readonly-box" v-if="file && signedUrl&&isReadOnly">
+        <div class="readonly-box" v-if="file && signedUrl && isReadOnly">
           <span class="file-link" @click="handleFileClick">
             <i class="fas fa-download file-icon"></i>
               {{ fileName }}
           </span>
         </div>
-        <div class="readonly-box" v-if="isReadOnly&&!file">첨부파일 없음</div>
+        <div class="readonly-box" v-if="isReadOnly && !signedUrl && !file">첨부파일 없음</div>
 
         <div v-if="!isReadOnly" class="upload-wrapper">
           <label class="upload-box">

--- a/src/features/approvals/components/approveType/ProposalForm.vue
+++ b/src/features/approvals/components/approveType/ProposalForm.vue
@@ -3,6 +3,7 @@ import { getFileUrl } from "@/features/common/api.js";
 import {ref, onMounted, watch} from "vue";
 import {generatePresignedUrl} from "@/features/announcement/api.js";
 import dayjs from "dayjs";
+import {useToast} from "vue-toastification";
 
 /* 부모에게 받아온 데이터 */
 const props = defineProps({
@@ -10,6 +11,8 @@ const props = defineProps({
   isReadOnly: { type: Boolean, default: true },
   approveFileDTO: { type: Array, default: () => [] }
 });
+
+const toast = useToast();
 
 /* 에러 메세지 */
 const errors = ref({
@@ -64,7 +67,7 @@ async function handleFileClick() {
     window.URL.revokeObjectURL(url);
   } catch (err) {
     console.error("파일 다운로드 실패:", err);
-    alert("파일 다운로드 중 오류가 발생했습니다.");
+    toast.error('파일 다운로드 중 에러가 발생했습니다.');
   }
 }
 
@@ -103,7 +106,7 @@ async function handleFileUpload(event) {
 
   } catch (err) {
     console.error("파일 업로드 실패:", err);
-    alert("파일 업로드 중 오류가 발생했습니다.");
+    toast.error('파일 업로드 중 오류가 발생했습니다.');
   }
 }
 

--- a/src/features/approvals/components/approveType/ProposalForm.vue
+++ b/src/features/approvals/components/approveType/ProposalForm.vue
@@ -56,7 +56,7 @@ async function handleFileClick() {
     const a = document.createElement("a");
 
     a.href = url;
-    a.download = file.value;
+    a.download = fileName.value;
 
     document.body.appendChild(a);
     a.click();

--- a/src/features/approvals/components/approveType/ReceiptForm.vue
+++ b/src/features/approvals/components/approveType/ReceiptForm.vue
@@ -3,12 +3,15 @@ import {computed, onBeforeUnmount, onMounted, ref, watch, watchEffect} from "vue
 import {getFileUrl} from "@/features/common/api.js";
 import {generatePresignedUrl} from "@/features/announcement/api.js";
 import {getOcrApi} from "@/features/approvals/api.js";
+import {useToast} from "vue-toastification";
 
 /* 파일과 관련된 변수들 */
 const imageUrl = ref(null);
 const fileName = ref(null);
 const uploadedFile = ref(null);
 const previewUrl = ref(null); // 미리보기용 url (업로드 시점에 미리 보기)
+
+const toast = useToast();
 
 /* ocr api 다 불러와지는 동안 로딩되도록 설정 */
 const isOcrLoading = ref(false);
@@ -144,7 +147,7 @@ async function handleFileUpload(event) {
   const validTypes = ['image/png', 'image/jpeg'];
 
   if (!validTypes.includes(file.type)) {
-    alert('PNG 또는 JPG 파일만 업로드할 수 있습니다.');
+    toast.error('PNG 또는 JPG 파일만 업로드할 수 있습니다.');
     return;
   }
 
@@ -194,7 +197,7 @@ async function handleFileUpload(event) {
 
   } catch (err) {
     console.error("파일 업로드 실패:", err);
-    alert("파일 업로드 중 오류가 발생했습니다.");
+    toast.error('파일 업로드 중 오류가 발생했습니다.');
   } finally {
     isOcrLoading.value = false;
   }

--- a/src/features/approvals/components/approveType/VacationForm.vue
+++ b/src/features/approvals/components/approveType/VacationForm.vue
@@ -195,7 +195,7 @@ async function handleFileClick() {
     const a = document.createElement("a");
 
     a.href = url;
-    a.download = file.value;
+    a.download = fileName.value;
 
     document.body.appendChild(a);
     a.click();

--- a/src/features/approvals/components/approveType/VacationForm.vue
+++ b/src/features/approvals/components/approveType/VacationForm.vue
@@ -184,15 +184,27 @@ async function fetchVacationFile() {
 }
 
 /* 파일 다운로드 하기 (클릭시 작동) */
-function handleFileClick() {
+async function handleFileClick() {
   if (!signedUrl.value || !file.value) return;
 
-  const link = document.createElement("a");
-  link.href = signedUrl.value;
-  link.download = file.value.originalFileName;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+  try {
+    const response = await fetch(signedUrl.value);
+    const blob = await response.blob();
+
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+
+    a.href = url;
+    a.download = file.value;
+
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    window.URL.revokeObjectURL(url);
+  } catch (err) {
+    console.error("파일 다운로드 실패:", err);
+    alert("파일 다운로드 중 오류가 발생했습니다.");
+  }
 }
 
 /* 파일 업로드 하기 */

--- a/src/features/approvals/components/approveType/VacationForm.vue
+++ b/src/features/approvals/components/approveType/VacationForm.vue
@@ -3,12 +3,15 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { getFileUrl } from "@/features/common/api.js";
 import { generatePresignedUrl } from "@/features/announcement/api.js";
 import { getRemainDayOff, getRemainRefresh } from "@/features/approvals/api.js";
+import {useToast} from "vue-toastification";
 
 /* 파일과 관련된 변수들 */
 const file = ref(null);
 const signedUrl = ref(null);
 const fileName = ref(null);
 const uploadedFile = ref(null);
+
+const toast = useToast();
 
 /* 부모에게 전달 받은 데이터 */
 const props = defineProps({
@@ -203,7 +206,7 @@ async function handleFileClick() {
     window.URL.revokeObjectURL(url);
   } catch (err) {
     console.error("파일 다운로드 실패:", err);
-    alert("파일 다운로드 중 오류가 발생했습니다.");
+    toast.error('파일 다운로드 중 에러가 발생했습니다.');
   }
 }
 
@@ -242,7 +245,7 @@ async function handleFileUpload(event) {
 
   } catch (err) {
     console.error("파일 업로드 실패:", err);
-    alert("파일 업로드 중 오류가 발생했습니다.");
+    toast.error('파일 업로드 중 에러가 발생했습니다.');
   }
 }
 

--- a/src/features/approvals/views/ApprovalList.vue
+++ b/src/features/approvals/views/ApprovalList.vue
@@ -27,7 +27,7 @@ const filterOptions = ref([]);
 const tabItems = [
   { label: '전체', value: 'ALL', icon: 'fa-building' },
   { label: '근태', value: 'ATTENDANCE', icon: 'fa-sitemap' },
-  { label: '영수증', value: 'RECEIPT', icon: 'fa-receipt' },
+  { label: '비용 처리', value: 'RECEIPT', icon: 'fa-receipt' },
   { label: '품의', value: 'PROPOSAL', icon: 'fa-user-tie' },
   { label: '취소', value: 'CANCEL', icon: 'fa-shield-alt' }
 ]
@@ -97,10 +97,10 @@ function generateBaseFilters() {
 }
 
 /* 동적 필터 */
-// 영수증 필터
+// 비용 처리 필터
 const receiptTypeFilter = {
   key: 'receiptType',
-  label: '영수증 종류',
+  label: '비용 처리 종류',
   icon: 'fa-receipt',
   type: 'select',
   options: ['전체', '식비', '출장비', '비품 구입비', '기타']
@@ -151,7 +151,7 @@ const statusTypeMap = {
 // 결재 종류
 const approveTypeMap = {
   'PROPOSAL': '품의',
-  'RECEIPT': '영수증',
+  'RECEIPT': '비용 처리',
   'BUSINESSTRIP': '출장',
   'VACATION': '휴가',
   'REMOTEWORK': '재택 근무',
@@ -192,7 +192,7 @@ function convertApproveType(tab, approveTypeLabel) {
       '휴가': 'VACATION'
     },
     'RECEIPT': {
-      '영수증': 'RECEIPT'
+      '비용 처리': 'RECEIPT'
     },
     'PROPOSAL': {
       '품의': 'PROPOSAL'
@@ -208,7 +208,7 @@ function convertApproveType(tab, approveTypeLabel) {
 }
 
 
-// 영수증 변환
+// 비용 처리 변환
 function convertReceipt(receiptType) {
   const statusMap = {
     '식비': 'MEALEXPENSE',
@@ -312,9 +312,13 @@ onMounted(fetchApprovals);
 
 /* 결재 내역 상세 보기로 이동 */
 function handleDetailClick(row) {
-    router.push(`/approval/detail/${row.approveId}`)
-      .catch(err => console.error('라우팅 실패:', err))
+  router.push({
+    path: `/approval/detail/${row.approveId}`,
+    state: { source: 'approvals' },
+    query: { from: 'approvals' }
+  }).catch(err => console.error('라우팅 실패:', err))
 }
+
 </script>
 
 <template>
@@ -325,7 +329,7 @@ function handleDetailClick(row) {
       :showTabs="false"
     />
 
-    <!-- 2. 탭 조건 (전체, 근태, 영수증, 품의, 취소) -->
+    <!-- 2. 탭 조건 (전체, 근태, 비용 처리, 품의, 취소) -->
     <TabNav
       :tabs="tabItems"
       v-model:selected="selectedTab"

--- a/src/features/approvals/views/ApproveDetailActionView.vue
+++ b/src/features/approvals/views/ApproveDetailActionView.vue
@@ -102,11 +102,18 @@ async function handleApprove(isApprove, reason) {
 
 /* 문서함으로 돌아가기 */
 function goBack() {
-  const from = route.query.from || window.history.state?.from
-  if (from === 'list') {
-    router.push({ name: 'ApprovalList' })
+  const from = route.query.from;
+  const tab = route.query.tab;
+
+  if (from === 'approvals') {
+    router.push('/approvals')
+  } else if (from === 'inbox') {
+    router.push({
+      path: '/approval/inbox',
+      query: tab ? { tab } : {}
+    })
   } else {
-    router.go(-1)
+    router.back();
   }
 }
 


### PR DESCRIPTION
closes #000

---

📌 개요
결재 문서 관련 오류 및 디자인 수정

🔨 주요 변경 사항
- 결재 내역 상세보기나 결재 작성시 active 해제되는 문제 해결
- 상세보기에서 문서함으로 갈 때, 경로 제대로 설정하기 
- 전체 결재 내역(`ApprovalList`) 에서도 영수증 대신 비용 처리로 용어 변경 
- 결재 내역 작성 후 toast 넣기
  - 결재 내역 작성하고 제출했을 때
  - 결재 내역이 다 작성되지 않았을 때
- 파일 다운이 안되고 페이지에서 열리고 있는 문제 해결

✅ 리뷰 요청 사항

⭐ 관련 이슈
#2 #3 #4 #5 
