### PR TITLE
feat : 문서 상세 보기에 참조 기능 추가

### DIFF
--- a/src/features/approvals/api.js
+++ b/src/features/approvals/api.js
@@ -69,3 +69,7 @@ export function approveOrReject(approvalConfirmRequest) {
     return api.patch(`/approval/decision`, approvalConfirmRequest);
 }
 
+/* 11. 참조 문서 열람 */
+export function checkApproval(documentId) {
+    return api.patch(`/approval/documents/${documentId}/reference`)
+}

--- a/src/features/approvals/components/FormSection.vue
+++ b/src/features/approvals/components/FormSection.vue
@@ -31,10 +31,12 @@ const {
   isReadOnly: { type: Boolean, default: true },
 });
 
-/* 대기 상태인 경우 */
+/* 대기 상태이면서 내가 결재자인 문서인 경우 */
 const canAction = computed(() => {
-  return approveDTO.statusType === 'PENDING'
+  return approveDTO.statusType === 'PENDING' && approveDTO.receivedType === 'APPROVAL';
 })
+
+console.log(approveDTO);
 
 /* form에 따라서 매핑 하기 */
 const formMap = {

--- a/src/features/approvals/components/approveType/BusinessTripForm.vue
+++ b/src/features/approvals/components/approveType/BusinessTripForm.vue
@@ -151,7 +151,7 @@ async function handleFileClick() {
     window.URL.revokeObjectURL(url);
   } catch (err) {
     console.error("파일 다운로드 실패:", err);
-    toast.error('파일 다운로드 중 에러가 발생했습니다.');
+    toast.error('파일 다운로드 중 오류가 발생했습니다.');
   }
 }
 

--- a/src/features/approvals/components/approveType/ProposalForm.vue
+++ b/src/features/approvals/components/approveType/ProposalForm.vue
@@ -67,7 +67,7 @@ async function handleFileClick() {
     window.URL.revokeObjectURL(url);
   } catch (err) {
     console.error("파일 다운로드 실패:", err);
-    toast.error('파일 다운로드 중 에러가 발생했습니다.');
+    toast.error('파일 다운로드 중 오류가 발생했습니다.');
   }
 }
 
@@ -179,12 +179,12 @@ onMounted(() => {
 
       <!-- 2. 품의 내역 -->
       <div class="form-group full-width">
-        <label class="form-label required">품의 내역<span class="asterisk"> *</span></label>
+        <label class="form-label required">품의 내역<span v-if="!isReadOnly" class="asterisk"> *</span></label>
         <div v-if="isReadOnly" class="readonly-box">
           {{ formData.content || "내용 없음" }}
         </div>
         <textarea v-else v-model="formData.content" class="form-textarea" required/>
-        <p v-if="errors.reason" class="warning-text">{{ errors.reason }}</p>
+        <p v-if="errors.reason && !isReadOnly" class="warning-text">{{ errors.reason }}</p>
       </div>
     </div>
   </div>

--- a/src/features/approvals/components/approveType/VacationForm.vue
+++ b/src/features/approvals/components/approveType/VacationForm.vue
@@ -206,7 +206,7 @@ async function handleFileClick() {
     window.URL.revokeObjectURL(url);
   } catch (err) {
     console.error("파일 다운로드 실패:", err);
-    toast.error('파일 다운로드 중 에러가 발생했습니다.');
+    toast.error('파일 다운로드 중 오류가 발생했습니다.');
   }
 }
 
@@ -245,7 +245,7 @@ async function handleFileUpload(event) {
 
   } catch (err) {
     console.error("파일 업로드 실패:", err);
-    toast.error('파일 업로드 중 에러가 발생했습니다.');
+    toast.error('파일 업로드 중 오류가 발생했습니다.');
   }
 }
 


### PR DESCRIPTION
closes #6

---

📌 개요
문서 상세 보기 참조 기능 추가

🔨 주요 변경 사항
- 결재 문서 form(출장, 품의, 휴가)에서 '에러'에서 '오류'로 용어 수정 (용어 통일을 위함)
- `approvals/api.js`에 문서 열람 api 연결
- `ApproveDetailActionView`에 문서 열람 api 동작하게 설정

✅ 리뷰 요청 사항

⭐ 관련 이슈
#6
