### PR TITLE
feat : 결재 문서 회수 기능

### DIFF
--- a/src/features/approvals/api.js
+++ b/src/features/approvals/api.js
@@ -73,3 +73,8 @@ export function approveOrReject(approvalConfirmRequest) {
 export function checkApproval(documentId) {
     return api.patch(`/approval/documents/${documentId}/reference`)
 }
+
+/* 12. 결재 문서 회수 */
+export function deleteApproval(documentId) {
+    return api.delete(`/approval/documents/${documentId}`)
+}

--- a/src/features/approvals/components/ReceivedApproval.vue
+++ b/src/features/approvals/components/ReceivedApproval.vue
@@ -307,7 +307,6 @@ onMounted(async () => {
   try {
     const deptRes = await getDepartments();
     departmentTree.value =  deptRes.data?.departmentInfoDTOList || [];
-    console.log(departmentTree.value);
   } catch (err) {
     console.error('부서 불러오기 실패:', err);
   }

--- a/src/features/approvals/views/ApproveEditCreateView.vue
+++ b/src/features/approvals/views/ApproveEditCreateView.vue
@@ -149,6 +149,7 @@ async function submitForm() {
           data-v-fb076351 data-v-f51fb21f
           @click="submitForm"
         >
+          <i data-v-fb076351="" class="fas fa-paper-plane"></i>
           제출
         </button>
       </div>


### PR DESCRIPTION
closes #144

---

📌 개요
결재 문서 회수 기능

🔨 주요 변경 사항
- `approvals/api.js`에서 결재 문서 회수 api 연결
- `FormSection`에서 결재 수정, 회수, 취소 버튼 생성 및 주석 달기
- `ReceivedApproval`에서 불필요한 log 삭제
- `ApproveDetailActionView`에 취소 기능 추가 (함수 연결)
- `ApproveEditCreateView`에 문서 작성 시 아이콘 추가

✅ 리뷰 요청 사항

⭐ 관련 이슈
#144
