### PR TITLE
fix : 취소 결재 추가 및 수정

### DIFF
--- a/src/features/approvals/components/FormSection.vue
+++ b/src/features/approvals/components/FormSection.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {computed, ref} from 'vue';
+import {computed, onMounted, ref, watch} from 'vue';
 import OvertimeForm from "@/features/approvals/components/approveType/OvertimeForm.vue";
 import CancelForm from "@/features/approvals/components/approveType/CancelForm.vue";
 import WorkCorrectionForm from "@/features/approvals/components/approveType/WorkCorrectionForm.vue";
@@ -9,10 +9,27 @@ import VacationForm from "@/features/approvals/components/approveType/VacationFo
 import ProposalForm from "@/features/approvals/components/approveType/ProposalForm.vue";
 import ReceiptForm from "@/features/approvals/components/approveType/ReceiptForm.vue";
 import ApproveReasonList from "@/features/approvals/components/ApproveReasonList.vue";
+import {submitApproval} from "@/features/approvals/api.js";
+import {useToast} from "vue-toastification";
+import {useRouter} from "vue-router";
+
+const router = useRouter();
+const toast = useToast();
+
+const cancelReasonError = ref('');
 
 /* 승인/반려 사유 */
 const reason = ref('');
 const rejectError = ref('');
+
+/* 결재 취소 요청 */
+const showCancelForm = ref(false);
+const showCancelButton = ref(true);
+
+const cancelForm = ref({
+  approveTitle: '결재 취소 요청',
+  cancelReason: '',
+});
 
 /* 부모에게 받아 온 값 */
 const {
@@ -20,6 +37,7 @@ const {
   parentApproveDTO,
   approveFileDTO,
   approveLineGroupDTO,
+  approveRefDTO,
   formDetail,
   isReadOnly
 } = defineProps({
@@ -27,6 +45,7 @@ const {
   parentApproveDTO: { type: Object, default: null },
   approveFileDTO: { type: Array, default: () => [] },
   approveLineGroupDTO: { type: Object },
+  approveRefDTO: { type: Array },
   formDetail: { type: Object, required: true },
   isReadOnly: { type: Boolean, default: true },
 });
@@ -70,6 +89,62 @@ function handleReject() {
   emit('reject', reason.value);
 }
 
+watch(() => cancelForm.value.cancelReason, (newVal) => {
+  if (!newVal || !newVal.trim()) {
+    cancelReasonError.value = '취소 사유는 반드시 입력해야 합니다.';
+  } else {
+    cancelReasonError.value = '';
+  }
+});
+
+async function submitCancelApproval() {
+  if (!cancelForm.value.cancelReason.trim()) {
+    cancelReasonError.value = '※ 취소 사유는 반드시 입력해야 합니다.';
+    toast.error('취소 사유를 입력해주세요.');
+    return;
+  }
+
+  cancelReasonError.value = ''; // 성공 시 초기화
+
+  const request = {
+    parentApproveId: approveDTO.approveId,
+    approveTitle: cancelForm.value.approveTitle,
+    approveType: 'CANCEL',
+    formDetail: {
+      cancelReason: cancelForm.value.cancelReason
+    },
+    attachments: [],
+
+    approveLineLists: (approveLineGroupDTO || []).map((group, index) => ({
+      statusId: 1,
+      approveLineOrder: index + 1,
+      isRequiredAll: group.approveLineDTO?.isRequiredAll ?? 'REQUIRED',
+      approveLineList: (group.approveLineListDTOs || []).map(approver => ({
+        empId: parseInt(approver.empId),
+        statusId: 1
+      }))
+    })),
+
+    refRequests: approveRefDTO.map(ref => ({
+      empId: parseInt(ref.empId),
+      isConfirmed: 'N'
+    }))
+  };
+  console.log(request);
+  try {
+    await submitApproval(request);
+    toast.success('취소 결재가 제출되었습니다.');
+    router.push({ name: 'MyApprovalsList', query: { tab: 'sent' } });
+  } catch (e) {
+    toast.error('취소 결재 제출에 실패했습니다.');
+  }
+}
+
+onMounted(() => {
+  if (!cancelForm.value.cancelReason.trim()) {
+    cancelReasonError.value = '* 취소 사유는 반드시 입력해야 합니다.';
+  }
+});
 </script>
 
 <template>
@@ -119,7 +194,7 @@ function handleReject() {
           <i class="fas fa-file-alt"></i>결재 내역
         </h3>
         <div class="form-group">
-          <!-- 각각의 결재 내역에 맞게 여결 -->
+          <!-- 각각의 결재 내역에 맞게 연결 -->
           <component
             :is="selectedFormComponent"
             v-if="selectedFormComponent"
@@ -189,12 +264,42 @@ function handleReject() {
             회수
           </button>
           <button
-            v-if="approveDTO.statusType === 'ACCEPTED' || approveDTO.statusType === 'REJECTED'"
+            v-if="(approveDTO.statusType === 'ACCEPTED' || approveDTO.statusType === 'REJECTED') && showCancelButton"
             type="button"
             class="btn-action btn-cancel"
+            @click="showCancelForm = true; showCancelButton = false"
             data-v-fb076351 data-v-f51fb21f
           >
             결재 취소
+          </button>
+        </div>
+      </div>
+
+      <!-- 7. 취소 결재와 관련된 요소 -->
+      <div v-if="showCancelForm" class="cancel-form-wrapper">
+        <div class="form-section">
+          <h3 class="section-title">
+            <i class="fas fa-pen-nib"></i>취소 제목<span class="asterisk"> *</span>
+          </h3>
+          <input v-model="cancelForm.approveTitle" type="text" class="form-input"/>
+        </div>
+
+        <div class="form-section">
+          <h3 class="section-title">
+            <i class="fas fa-file-alt"></i>취소 사유<span class="asterisk"> *</span>
+          </h3>
+          <textarea v-model="cancelForm.cancelReason" class="form-textarea" />
+          <p v-if="cancelReasonError" class="error-message">{{ cancelReasonError }}</p>
+        </div>
+
+        <div class="approve-action-wrapper">
+          <button
+            type="button"
+            class="btn-action btn-edit"
+            @click="submitCancelApproval"
+            data-v-fb076351 data-v-f51fb21f
+          >
+            취소 결재 제출
           </button>
         </div>
       </div>
@@ -342,5 +447,8 @@ function handleReject() {
   align-self: flex-start;
 }
 
-
+.asterisk {
+  color: var(--error);
+  margin-left: 4px;
+}
 </style>

--- a/src/features/approvals/components/approveType/CancelForm.vue
+++ b/src/features/approvals/components/approveType/CancelForm.vue
@@ -41,15 +41,6 @@ const matchedComponent = computed(() => {
   }
 });
 
-/* 취소 사유 입력 - 수정 부분을 위해 필요한 부분 */
-function validateForm() {
-  if (!cancelForm.value.cancelReason.trim()) {
-    alert('취소 사유를 반드시 입력해주세요.');
-    return false;
-  }
-  return true;
-}
-
 /* mount 하기 */
 onMounted(async () => {
   const parentId = props.parentApproveDTO.approveId;
@@ -85,7 +76,6 @@ onMounted(async () => {
       <div class="form-group full-width">
         <label class="form-label required">취소 사유</label>
         <input v-model="formData.cancelReason" class="form-textarea" readonly></input>
-<!--        <textarea v-model="cancelForm.cancelReason" class="form-textarea" required></textarea>-->
       </div>
     </div>
   </div>

--- a/src/features/approvals/components/approveType/WorkCorrectionForm.vue
+++ b/src/features/approvals/components/approveType/WorkCorrectionForm.vue
@@ -113,7 +113,6 @@ async function fetchMyWorks() {
     const passedWorkId = route.query.workId;
     const found = works.find(w => String(w.workId) === String(passedWorkId));
 
-    console.log(found.workId)
     if (found) {
       selectedWorkId.value = found.workId;
       updateBeforeTimes(found);

--- a/src/features/approvals/views/ApproveDetailActionView.vue
+++ b/src/features/approvals/views/ApproveDetailActionView.vue
@@ -100,22 +100,6 @@ async function handleDelete() {
   }
 }
 
-// async function handleCancel() {
-//   if (!confirm('결재를 취소하시겠습니까?')) return;
-//
-//   try {
-//     loading.value = true;
-//     await cancelApproval(route.params.documentId); // ← API 연결 필요
-//     alert('결재가 취소되었습니다.');
-//     await fetchApproval(); // ← 상태 갱신
-//   } catch (e) {
-//     console.error('취소 실패:', e);
-//     alert('취소에 실패했습니다.');
-//   } finally {
-//     loading.value = false;
-//   }
-// }
-
 /* 내 결재선 찾기 */
 watchEffect(() => {
   if (!approval.value) return;
@@ -209,12 +193,14 @@ onMounted(fetchApproval)
 
   <!-- 2. 결재 내역 나오는 부분  -->
   <div v-if="approval" class="container">
+
     <div class="approval-page">
       <div class="page-body">
         <FormSection
           :approveDTO="approval.approveDTO"
           :parentApproveDTO="approval.parentApproveDTO"
           :approveLineGroupDTO="approval.approveLineGroupDTO"
+          :approveRefDTO="approval.approveRefDTO"
           :approveFileDTO="approval.approveFileDTO"
           :formDetail="approval.formDetail"
           :isReadOnly="true"

--- a/src/features/approvals/views/ApproveEditCreateView.vue
+++ b/src/features/approvals/views/ApproveEditCreateView.vue
@@ -76,7 +76,7 @@ async function submitForm() {
         empId: approver.empId
       }))
     })),
-    approveRefList: selectedRefList.value.map(ref => ({
+    refRequests: selectedRefList.value.map(ref => ({
       empId: ref.empId,
       isConfirmed: 'N'
     }))
@@ -139,6 +139,7 @@ async function submitForm() {
           v-model:modelValueReferenceList="selectedRefList"
           :approve-type="form.approveType"
           :read-only="false"
+          :is-read-only="form.approveType === 'CANCEL'"
         />
       </div>
 


### PR DESCRIPTION
closes #5

---

📌 개요
취소 결재 관련 수정(취소 결재는 부모 문서 쪽에서 이유가 뜨는 게 더 좋다고 생각해 결재 내용 수정)

🔨 주요 변경 사항
- `FormSection` 에서 클릭시 취소 결재가 될 수 있게 수정 
- `CancelForm`은 읽기 모드로만 지원될 수 있게 textarea 제거
- `DetailActionForm`에서 취소 결재 제출 함수 제거
- `ApproveEditCreateView`에서 approveRefList -> refRequests로 수정 (백엔드에서 refRequests로 되어 있음)

✅ 리뷰 요청 사항

⭐ 관련 이슈
#5
