### PR TITLE
[feat #199] 결재 문서 수정 기능

### DIFF
--- a/src/components/common/CommonModal.vue
+++ b/src/components/common/CommonModal.vue
@@ -118,7 +118,7 @@ watch(() => props.visible, (val) => {
   width: 100%;
   padding: 14px 28px;
   border-radius: var(--radius-md);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   font-weight: 600;
   cursor: pointer;
   display: flex;

--- a/src/features/approvals/api.js
+++ b/src/features/approvals/api.js
@@ -78,3 +78,8 @@ export function checkApproval(documentId) {
 export function deleteApproval(documentId) {
     return api.delete(`/approval/documents/${documentId}`)
 }
+
+/* 13. 결재 문서 수정 */
+export function updateApproval(request, documentId) {
+    return api.put(`/approval/documents/${documentId}`, request)
+}

--- a/src/features/approvals/components/FormSection.vue
+++ b/src/features/approvals/components/FormSection.vue
@@ -76,7 +76,7 @@ const selectedFormComponent = computed(() => {
   return formMap[approveDTO.approveType] || null;
 });
 
-const emit = defineEmits(['approve', 'reject', 'request-delete']);
+const emit = defineEmits(['approve', 'reject', 'request-delete', 'edit']);
 
 /* 결재 문서 반려 하기 */
 function handleReject() {
@@ -134,7 +134,7 @@ async function submitCancelApproval() {
   try {
     await submitApproval(request);
     toast.success('취소 결재가 제출되었습니다.');
-    router.push({ name: 'MyApprovalsList', query: { tab: 'sent' } });
+    await router.push({name: 'MyApprovalsList', query: {tab: 'sent'}});
   } catch (e) {
     toast.error('취소 결재 제출에 실패했습니다.');
   }
@@ -250,6 +250,7 @@ onMounted(() => {
             v-if="approveDTO.statusType === 'PENDING' "
             type="button"
             class="btn-action btn-edit"
+            @click="$emit('edit')"
             data-v-fb076351 data-v-f51fb21f
           >
             수정

--- a/src/features/approvals/components/WriteFormSection.vue
+++ b/src/features/approvals/components/WriteFormSection.vue
@@ -7,10 +7,13 @@ import BusinessTripForm from '@/features/approvals/components/approveType/Busine
 import VacationForm from '@/features/approvals/components/approveType/VacationForm.vue'
 import ProposalForm from '@/features/approvals/components/approveType/ProposalForm.vue'
 import ReceiptForm from '@/features/approvals/components/approveType/ReceiptForm.vue'
+import {useRoute} from "vue-router";
 
+const route = useRoute();
 const selectedFormComponent = ref(WorkCorrectionForm);
 const formData = ref({});
 const isDropdownOpen = ref(false)
+const isEditMode = computed(() => !!route.params.documentId)
 
 const props = defineProps({
   title: String,
@@ -90,8 +93,10 @@ watch(
   (newType) => {
     selectedFormComponent.value = formMap[newType] || null;
 
-    emit('update:title', ''); // 제목 초기화
-    emit('update:formData', {}); // form 데이터 초기화
+    if (!isEditMode.value) {
+      emit('update:title', '');
+      emit('update:formData', {});
+    }
   },
   { immediate: true }
 )

--- a/src/features/approvals/components/approveType/ReceiptForm.vue
+++ b/src/features/approvals/components/approveType/ReceiptForm.vue
@@ -133,7 +133,10 @@ async function fetchReceiptImage() {
 }
 
 watchEffect(() => {
-  const file = props.approveFileDTO[0];
+  const file = props.isReadOnly
+    ? (props.approveFileDTO?.[0] || props.formData?.attachments?.[0])
+    : null;
+
   if (props.isReadOnly && file && file.s3Key) {
     fetchReceiptImage();
   }

--- a/src/features/approvals/router.js
+++ b/src/features/approvals/router.js
@@ -18,5 +18,11 @@ export const approvalsRoutes = [
         path: '/approval/write',
         name: 'ApprovalWrite',
         component: () => import('@/features/approvals/views/ApproveEditCreateView.vue')
+    },
+    {
+        path: '/approval/edit/:documentId',
+        name: 'ApprovalEdit',
+        component: () => import('@/features/approvals/views/ApproveEditCreateView.vue')
     }
+
 ];

--- a/src/features/approvals/views/ApproveDetailActionView.vue
+++ b/src/features/approvals/views/ApproveDetailActionView.vue
@@ -74,11 +74,22 @@ async function fetchApproval() {
   }
 }
 
-// function handleEdit() {
-//   const documentId = route.params.documentId;
-//   router.push({ name: 'ApprovalEdit', params: { documentId } });
-// }
+/* 수정 클릭하기 */
+function handleEdit() {
+  sessionStorage.setItem('approvalEditState', JSON.stringify({
+    approveDTO: approval.value.approveDTO,
+    parentApproveDTO: approval.value.parentApproveDTO,
+    approveLineGroupDTO: approval.value.approveLineGroupDTO,
+    approveRefDTO: approval.value.approveRefDTO,
+    approveFileDTO: approval.value.approveFileDTO,
+    formDetail: approval.value.formDetail
+  }));
 
+  router.push({
+    name: 'ApprovalEdit',
+    params: { documentId: route.params.documentId }
+  });
+}
 
 /* 결재 문서 회수하기 */
 async function handleDelete() {
@@ -92,7 +103,7 @@ async function handleDelete() {
 
     switch (errorCode) {
       case '30026':
-        toast.error('결재가 시작되어 회수할 수 없습니다.');
+        toast.error('결재가 시작되어 수정, 회수할 수 없습니다.');
         break;
       default:
         toast.error('삭제 중 오류가 발생했습니다.');
@@ -207,6 +218,7 @@ onMounted(fetchApproval)
           @approve="(reason) => handleApprove(true, reason)"
           @reject="(reason) => handleApprove(false, reason)"
           @request-delete="showDeleteConfirmModal = true"
+          @edit="handleEdit()"
         />
         <ApprovalSideSection
           :approveLineGroupDTO="approval.approveLineGroupDTO"


### PR DESCRIPTION
closes #199

---

📌 개요
결재 문서 수정 기능

🔨 주요 변경 사항
- `CommonModal`에서 글씨 크기 조정
- `approvals/api.js`에 문서 수정 api 연결
- `approvals/router.js`에 수정 경로 연결
- `FormSection`에 edit 될 수 있게 버튼에 emit 연결
- `WriteForm`에서 작성 모드와 수정 모드 분리
- `ApproveDetailActionView`에서 수정 클릭 시 수정 페이지로 넘어가면서 데이터 전달하게 설정
- `ApproveEditCreateView`에 수정 모드 추가

✅ 리뷰 요청 사항

⭐ 관련 이슈
#199
