### PR TITLE
feat : 결재와 관련된 부분 대시보드에 연결

### DIFF
--- a/src/features/mypage/components/DocumentCard.vue
+++ b/src/features/mypage/components/DocumentCard.vue
@@ -5,17 +5,30 @@
       결재문서
     </div>
     <div class="doc-buttons">
-      <button class="doc-btn">
-        <span class="material-icons">hourglass_empty</span> 대기문서
+      <button class="doc-btn" @click="goInbox('sent')">
+        <span class="material-icons">send</span> 보낸 문서
       </button>
-      <button class="doc-btn">
-        <span class="material-icons">check_circle</span> 처리문서
+      <button class="doc-btn" @click="goInbox('received ')">
+        <span class="material-icons">inbox</span> 받은 문서
       </button>
     </div>
   </div>
 </template>
 
-<script setup></script>
+<script setup>
+import {useRouter} from "vue-router";
+
+const router = useRouter();
+
+function goInbox(tab) {
+  router.push({
+    path: '/approval/inbox',
+    query: tab ? { tab } : {}
+  })
+}
+
+
+</script>
 
 <style scoped>
 .doc-buttons {

--- a/src/features/mypage/components/VacationInfoCard.vue
+++ b/src/features/mypage/components/VacationInfoCard.vue
@@ -2,10 +2,13 @@
   <div class="card leave-info">
     <div class="side-section-title">
       <span class="material-icons" style="color:var(--warning);">beach_access</span>
-      잔여 연차
+      잔여 휴가
     </div>
-    <p><strong>남은 일수:</strong>
-      <span class="remaining-days">{{ remainingDays }}일</span>
+    <p><strong>잔여 연차: </strong>
+      <span class="remaining-days">{{ remainDayOff }}</span>
+    </p>
+    <p><strong>잔여 리프레시 휴가: </strong>
+      <span class="remaining-days">{{ remainRefresh }}</span>
     </p>
 
 <!--    <div class="leave-subtitle">이번달 휴가/출장 일정</div>-->
@@ -18,13 +21,35 @@
 </template>
 
 <script setup>
+import {onMounted, ref} from "vue";
+import {getRemainDayOff, getRemainRefresh} from "@/features/approvals/api.js";
+
+/* 잔여 휴가 수 */
+const remainDayOff = ref(null);
+const remainRefresh = ref(null);
+
 defineProps({
-  remainingDays: Number,
   vacations: {
     type: Array,
     default: () => []
   }
 })
+
+/* 잔여 연차를 가져오는 함수 */
+async function fetchRemainingVacation() {
+  try {
+    const dayOff = await getRemainDayOff();
+    const refresh = await getRemainRefresh();
+
+    remainDayOff.value = dayOff.data.data.remainingDayoffHours/8 + '일';
+    remainRefresh.value = refresh.data.data.remainingRefreshDays + '일';
+
+  } catch (err) {
+    console.error("잔여 연차 불러오기 실패:", err);
+  }
+}
+
+onMounted(fetchRemainingVacation);
 </script>
 
 <style scoped>

--- a/src/features/mypage/views/DashBoardView.vue
+++ b/src/features/mypage/views/DashBoardView.vue
@@ -89,11 +89,11 @@ const handleEventClick = (event) => {
   }
 }
 
-// 교정 요청 페이지 이동
+// 출퇴근 정정 요청 페이지 이동
 const goToCorrectionPage = () => {
   const workId = selectedAttendance.value?.workId
   if (workId) {
-    router.push({ name: 'WorkCorrectionRequest', query: { workId } })
+    router.push({ name: 'ApprovalWrite', query: { workId } })
   }
 }
 


### PR DESCRIPTION
closes #000

---

📌 개요
결재와 관련된 부분 대시보드에 연결

🔨 주요 변경 사항
- `DashBoardView`에서 출퇴근 정정 페이지로 이동할 수 있게 설정
- `DocumentCard`에서 '대기 문서'와 '처리 문서' 대신, '받은 문서'와'보낸 문서'로 수정
- `VacationInfoCard`에 잔여 연차와 잔여 리프레시 휴가 api 연결

✅ 리뷰 요청 사항

⭐ 관련 이슈
#
