### PR TITLE
[style] 회사 정보 페이지 스타일 수정

### DIFF
--- a/src/components/common/HeaderWithTabs.vue
+++ b/src/components/common/HeaderWithTabs.vue
@@ -50,8 +50,6 @@
 </template>
 
 <script setup>
-import { ref, defineEmits, defineProps, watch } from 'vue';
-
 const props = defineProps({
   headerItems: {
     type: Array,

--- a/src/components/common/NavigationTab.vue
+++ b/src/components/common/NavigationTab.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { defineProps, defineEmits, onMounted, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 
 const props = defineProps({
   tabs: {

--- a/src/features/company/views/CompanyInfoView.vue
+++ b/src/features/company/views/CompanyInfoView.vue
@@ -142,7 +142,7 @@ onMounted(async () => {
 .header-title {
   font-size: 2.1rem;
   font-weight: 700;
-  color: #334155;
+  color: var(--font-main);
   margin: 0 0 0.2rem 0;
 }
 


### PR DESCRIPTION
closes #000

---

📌 개요
- 회사 정보 페이지 스타일 수정

🔨 주요 변경 사항
- 회사 정보 페이지 헤더 글씨 색상 다른 문제 수정
- 불필요한 import 문 삭제 (HeaderWithTabs, NavigationTab)

✅ 리뷰 요청 사항
- 회사 정보 페이지 및 조직도 페이지의 경우 2.1rem 사용하고 있어서 글씨 크기가 다름 (HeaderWithTabs는 2rem)
  -> 요청 시 둘 다 2rem으로 수정 가능

⭐ 관련 이슈
#
