### PR TITLE
refactor: 사원 CSV 등록 템플릿 다운로드 로직 개선

### DIFF
--- a/src/features/employee/views/CSVUploadView.vue
+++ b/src/features/employee/views/CSVUploadView.vue
@@ -157,34 +157,38 @@ async function downloadTemplate() {
     link.download = fileName
     link.click()
   } catch (e) {
-    const headers = [
-      "이름",
-      "이메일 주소",
-      "부서명",
-      "직위명",
-      "성별",
-      "주소",
-      "연락처",
-      "입사일",
-      "재직 상태",
-      "생년월일",
-      "부여 연차 시간",
-      "부여 리프레시 휴가 일수"
-    ]
+    try {
+      const headers = [
+        "이름",
+        "이메일 주소",
+        "부서명",
+        "직위명",
+        "성별",
+        "주소",
+        "연락처",
+        "입사일",
+        "재직 상태",
+        "생년월일",
+        "부여 연차 시간",
+        "부여 리프레시 휴가 일수"
+      ]
 
-    // 따옴표 포함된 CSV 문자열 만들기
-    const quotedHeaders = headers.map(h => `"${h.replace(/"/g, '""')}"`)
-    const csvContent = quotedHeaders.join(',') + '\n'
+      // 따옴표 포함된 CSV 문자열 만들기
+      const quotedHeaders = headers.map(h => `"${h.replace(/"/g, '""')}"`)
+      const csvContent = quotedHeaders.join(',') + '\n'
 
-    // UTF-8 BOM 포함 (엑셀 호환용)
-    const blob = new Blob(["\uFEFF" + csvContent], { type: 'text/csv;charset=utf-8;' })
+      // UTF-8 BOM 포함 (엑셀 호환용)
+      const blob = new Blob(["\uFEFF" + csvContent], {type: 'text/csv;charset=utf-8;'})
 
-    const link = document.createElement('a')
-    link.href = URL.createObjectURL(blob)
-    link.setAttribute('download', 'employees_template.csv')
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
+      const link = document.createElement('a')
+      link.href = URL.createObjectURL(blob)
+      link.setAttribute('download', 'employees_template.csv')
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+    } catch (e) {
+      toast.error("CSV 템플릿 다운로드 실패")
+    }
   }
 }
 

--- a/src/features/employee/views/CSVUploadView.vue
+++ b/src/features/employee/views/CSVUploadView.vue
@@ -157,8 +157,34 @@ async function downloadTemplate() {
     link.download = fileName
     link.click()
   } catch (e) {
-    const message = e?.response?.data?.message;
-    toast.error(message || 'CSV 템플릿 다운로드에 실패했습니다.')
+    const headers = [
+      "이름",
+      "이메일 주소",
+      "부서명",
+      "직위명",
+      "성별",
+      "주소",
+      "연락처",
+      "입사일",
+      "재직 상태",
+      "생년월일",
+      "부여 연차 시간",
+      "부여 리프레시 휴가 일수"
+    ]
+
+    // 따옴표 포함된 CSV 문자열 만들기
+    const quotedHeaders = headers.map(h => `"${h.replace(/"/g, '""')}"`)
+    const csvContent = quotedHeaders.join(',') + '\n'
+
+    // UTF-8 BOM 포함 (엑셀 호환용)
+    const blob = new Blob(["\uFEFF" + csvContent], { type: 'text/csv;charset=utf-8;' })
+
+    const link = document.createElement('a')
+    link.href = URL.createObjectURL(blob)
+    link.setAttribute('download', 'employees_template.csv')
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
   }
 }
 


### PR DESCRIPTION
closes #000

---

📌 개요
- CSV 템플릿 다운로드 로직 개선

🔨 주요 변경 사항
- S3에서 다운로드 실패하면 프론트 서버에서 직접 CSV 파일 생성하여 다운로드
- (거의 가능성은 없다고 하지만) 만약 서버에서 다운로드도 실패하면 토스트 알림 생성 (catch 블록 내의 중첩 try-catch 블록)
✅ 리뷰 요청 사항

⭐ 관련 이슈
#
