### PR TITLE
[refactor] 발령 및 사원 등록 로직 수정

### DIFF
--- a/src/components/common/form/DeptList.vue
+++ b/src/components/common/form/DeptList.vue
@@ -4,7 +4,10 @@ import { ref, watch, computed, onMounted, onBeforeUnmount } from "vue";
 
 const props = defineProps({
   modelValue: [String, Number],
-  list: Array
+  list: Array,
+  showNull: { type: Boolean, default: true },
+  nullLabel: { type: String, default: '부서 없음' },
+  defaultLabel: { type: String, default: '부서 선택' },
 });
 const emit = defineEmits(['update:modelValue']);
 
@@ -29,11 +32,14 @@ function TreeToMap(data) {
   // "상위 부서 없음" 항목 추가
   const noneId = null;
   treeMap[noneId] = {
-    text: '부서 없음',
+    text: props.nullLabel,
     children: [],
     state: { opened: false }
   };
-  rootIds.push(noneId);
+
+  if (props.showNull) {
+    rootIds.push(noneId);
+  }
 
   function traverse(node, parent = null) {
     const id = String(node.deptId);
@@ -66,7 +72,7 @@ watch(() => props.list, (newVal) => {
 }, { immediate: true });
 
 const selectedLabel = computed(() => {
-  if (props.modelValue === null) return '부서 없음';
+  if (props.modelValue === null) return props.nullLabel;
   const id = String(props.modelValue);
   return treeNodes.value[id]?.text || '';
 });
@@ -86,7 +92,7 @@ onBeforeUnmount(() => document.removeEventListener('click', handleClickOutside))
 <template>
   <div class="dropdown-wrapper" ref="dropdownRef">
     <div class="dropdown-input" @click="toggleDropdown">
-      {{ selectedLabel || '부서 선택' }}
+      {{ selectedLabel || defaultLabel }}
       <i class="fas fa-chevron-down" :class="{ open: isOpen }"></i>
     </div>
 

--- a/src/components/common/form/FieldRenderer.vue
+++ b/src/components/common/form/FieldRenderer.vue
@@ -180,6 +180,9 @@
       <DeptList
           v-else-if="field.type === 'deptList'"
           :list="field.list"
+          :showNull="field.showNull ?? true"
+          :nullLabel="field.nullLabel ?? '부서 없음'"
+          :defaultLabel="field.defaultLabel ?? '부서 선택'"
           v-model="model[field.key]"
       />
     </template>

--- a/src/features/employee/views/AdminEmployeeProfileView.vue
+++ b/src/features/employee/views/AdminEmployeeProfileView.vue
@@ -11,6 +11,7 @@ import {useRoute, useRouter} from "vue-router";
 import HistoryInfoEditable from "@/features/employee/components/profile/HistoryInfoEditable.vue";
 import HeaderWithTabs from "@/components/common/HeaderWithTabs.vue";
 import DeleteConfirmToast from "@/components/common/DeleteConfirmToast.vue";
+import {toastError} from "@/util/toastError.js";
 
 const route = useRoute();
 const router = useRouter();
@@ -86,8 +87,7 @@ const getEmpInfo = async () => {
     employeeDetails.value = response.employeeDetails;
     employeeRecords.value = response.employeeRecords;
   } catch (e) {
-    const message = e?.response?.data?.message;
-    toast.error(message || '사원 정보 조회 실패')
+    toast.error('사원 정보 조회 실패')
   }
 
 }
@@ -99,8 +99,7 @@ const handleRegisterSubmit = async(req) => {
     modalVisible.value = false;
     await getEmpInfo();
   } catch (e) {
-    const message = e?.response?.data?.message;
-    toast.error(message || '개인정보 수정 실패')
+    toastError(e, '개인정보 수정 실패')
   }
 }
 
@@ -163,8 +162,7 @@ const handleHistorySubmit = async (formData, idsToDelete) => {
     toast.success('이력 정보를 수정했습니다!');
     await getEmpInfo();
   } catch (e) {
-    const message = e?.response?.data?.message;
-    toast.error(message || '이력 정보 수정 실패')
+    toastError(e, '이력 정보 수정 실패')
   }
 };
 

--- a/src/features/employee/views/AppointListView.vue
+++ b/src/features/employee/views/AppointListView.vue
@@ -9,6 +9,7 @@ import {getDepartments, getPositions} from "@/features/works/api.js";
 import {createAppoint, getAppoints, getEmployeeDetails} from "@/features/employee/api.js";
 import {useToast} from "vue-toastification";
 import dayjs from "dayjs";
+import {toastError} from "@/util/toastError.js";
 
 const toast = useToast();
 const currentPage = ref(1);
@@ -92,8 +93,7 @@ const fetchSummary = async (values) => {
     appoints.value = [];
     pagination.value = {currentPage: 1, totalPage: 1};
 
-    const message = e?.response?.data?.message;
-    toast.error(message || '인사 발령 내역 조회 실패')
+    toast.error('인사 발령 내역 조회 실패')
   }
 }
 
@@ -128,7 +128,7 @@ const req = reactive({
   type: null,
   positionId: null,
   deptId: null,
-  appointDate: dayjs().format('YYYY-MM-DD')
+  // appointDate: dayjs().format('YYYY-MM-DD') // 발령일 선택 제공 시 필요
 });
 
 const initializeRequest = () => {
@@ -136,7 +136,7 @@ const initializeRequest = () => {
   req.type = null;
   req.positionId = null;
   req.deptId = null;
-  req.appointDate = dayjs().format('YYYY-MM-DD');
+  // req.appointDate = dayjs().format('YYYY-MM-DD'); // 발령일 선택 제공 시 필요
 }
 
 watch(
@@ -220,6 +220,9 @@ function getDeptField() {
     editable: true,
     required: true,
     list: deptOptions.value,
+    showNull: false,
+    nullLabel: '',
+    defaultLabel: '선택',
     value: req.deptId
   };
 }
@@ -248,7 +251,7 @@ const modalSections = computed(() => [
         },
         getPositionField(),
         getDeptField(),
-        {key: 'appointDate', label: '발령일', type: 'date', editable: true, required: true}
+        // {key: 'appointDate', label: '발령일', type: 'date', editable: true, required: true} // 발령일 선택 제공 시 필요
       ]
     }
   ]
@@ -268,8 +271,7 @@ const handleRegisterSubmit = async (req) => {
     handleSearch(); // 목록 새로고침
     toast.success("발령 등록 성공")
   } catch (e) {
-    const message = e?.response?.data?.message;
-    toast.error(message || '발령 등록 실패')
+    toastError(e, '발령 등록 실패')
   }
 };
 </script>

--- a/src/features/employee/views/CSVUploadView.vue
+++ b/src/features/employee/views/CSVUploadView.vue
@@ -57,6 +57,7 @@ import HeaderWithTabs from "@/components/common/HeaderWithTabs.vue"
 import {createEmployees, getCSVTemplate} from '@/features/employee/api'
 import {useToast} from "vue-toastification";
 import {useRouter} from "vue-router";
+import {toastError} from "@/util/toastError.js";
 
 const router = useRouter()
 
@@ -71,6 +72,7 @@ const requiredFields = [
   {key: 'name', icon: 'fa-user', type: 'input', label: '이름', placeholder: '사원 이름', required: true},
   {key: 'email', icon: 'fa-envelope', label: '이메일', placeholder: 'gildong@example.com', required: true},
   {key: 'position', icon: 'fa-star', label: '직위', placeholder: '시스템에 등록된 직위명', required: true},
+  {key: 'department', icon: 'fa-building', label: '부서', placeholder: '시스템에 등록된 부서명', required: true},
   {key: 'birthDate', icon: 'fa-birthday-cake', label: '생년월일', placeholder: 'YYYY-MM-DD', required: true},
   {key: 'phone', icon: 'fa-phone', label: '연락처', placeholder: '010-0000-0000', required: true},
   {key: 'address', icon: 'fa-map-marker-alt', label: '주소', placeholder: '거주지 주소 (도로명 주소)', required: true},
@@ -78,7 +80,6 @@ const requiredFields = [
 ]
 
 const optionalFields = [
-  {key: 'department', icon: 'fa-building', label: '부서', placeholder: '시스템에 등록된 부서명'},
   {key: 'status', icon: 'fa-building', label: '재직 상태', placeholder: '재직, 휴직, 퇴사 중 하나'},
   {key: 'hireDate', icon: 'fa-calendar', label: '입사일', placeholder: 'YYYY-MM-DD'},
   {key: 'dayoff', icon: 'fa-clock', label: '부여 연차 시간 (예: 15일 -> 120)', placeholder: '숫자 입력'},
@@ -86,7 +87,6 @@ const optionalFields = [
 ]
 
 const csvDefaults = [
-  {icon: 'fa-info-circle', color: 'blue', text: '부서: 없음'},
   {icon: 'fa-info-circle', color: 'blue', text: '재직 상태: 재직'},
   {icon: 'fa-info-circle', color: 'blue', text: '입사일: CSV 등록일'},
   {icon: 'fa-info-circle', color: 'blue', text: '부여 연차 시간: 입사일에 따른 자동 계산값 (근로기준법 상 최솟값)'},
@@ -130,10 +130,9 @@ async function uploadCSV() {
     await createEmployees(formData)
     toast.success('CSV 파일이 성공적으로 업로드되었습니다!')
     removeFile()
-    router.push('/employees')
+    router.push({ path: '/employees', query: { order: 'DESC' } })
   } catch (e) {
-    const message = e?.response?.data?.message;
-    toast.error(message || '업로드 중 오류가 발생했습니다.')
+    toastError(e, '업로드 중 오류가 발생했습니다.')
   } finally {
     uploading.value = false
   }

--- a/src/features/employee/views/ContractListView.vue
+++ b/src/features/employee/views/ContractListView.vue
@@ -117,8 +117,7 @@ const fetchSummary = async (values) => {
     contracts.value = [];
     pagination.value = {currentPage: 1, totalPage: 1};
 
-    const message = e?.response?.data?.message;
-    toast.error(message || '계약서 목록 조회 실패')
+    toast.error('계약서 목록 조회 실패')
   }
 };
 
@@ -180,7 +179,7 @@ function getModalSections(type) {
   if (salaryEditable) {
     fields.push({
       key: 'salary',
-      label: '연봉',
+      label: '연봉 (원)',
       type: 'input',
       editable: true,
       required: true,

--- a/src/features/mypage/views/MyContractsView.vue
+++ b/src/features/mypage/views/MyContractsView.vue
@@ -73,9 +73,7 @@ const fetchSummary = async (values) => {
   } catch (e) {
     contracts.value = [];
     pagination.value = {currentPage: 1, totalPage: 1};
-
-    const message = e?.response?.data?.message;
-    toast.error(message || '계약서 목록 조회 실패')
+    toast.error('계약서 목록 조회 실패')
   }
 };
 

--- a/src/features/works/views/WorkListView.vue
+++ b/src/features/works/views/WorkListView.vue
@@ -13,6 +13,7 @@ import {
   getWorks,
   getWorkTypes
 } from "@/features/works/api.js";
+import {toastError} from "@/util/toastError.js";
 
 const currentPage = ref(1);
 const pagination = ref({currentPage: 1, totalPage: 1});
@@ -130,9 +131,7 @@ const fetchSummary = async (values) => {
   };
 
   try {
-    console.log(params);
     const resp = await getWorks(params);
-    console.log(resp);
 
     works.value = resp.works || [];
     const current = resp.pagination?.currentPage || 1;
@@ -142,8 +141,7 @@ const fetchSummary = async (values) => {
     works.value = [];
     pagination.value = {currentPage: 1, totalPage: 1};
 
-    const message = e?.response?.data?.message;
-    toast.error(message || '근태 내역 조회 실패')
+    toast.error('근태 내역 조회 실패')
   }
 }
 
@@ -209,8 +207,7 @@ const openDetailsModal = async (work) => {
     workDetails.value = await getWorkDetails(workId);
   } catch (e) {
     workDetails.value = null;
-    const message = e?.response?.data?.message;
-    toast.error(message || '출퇴근 상세 내용 조회 실패')
+    toast.error('출퇴근 상세 내용 조회 실패')
   } finally {
     loadingDetails.value = false;
   }

--- a/src/util/toastError.js
+++ b/src/util/toastError.js
@@ -1,0 +1,27 @@
+// utils/toastError.js
+import { useToast } from "vue-toastification";
+
+export function toastError(e, defaultMessage) {
+    const toast = useToast();
+    const raw = e?.response?.data?.message || '';
+
+    const isValidationError = raw.startsWith('입력 값 검증 오류입니다.') && raw.includes('[') && raw.includes(']');
+    if (isValidationError) {
+        const matched = raw.match(/\[(.*?)\]/);
+        if (matched) {
+            const firstMessage = matched[1].split(' : ')[1]?.trim();
+            toast.error(firstMessage || '입력 값 검증 오류입니다.');
+        } else {
+            toast.error('입력 값 검증 오류입니다.');
+        }
+        /* 여러 개 보여주고 싶으면 */
+        // const matchedMessages = [...raw.matchAll(/\[(.*?)\]/g)];
+        // const messages = matchedMessages.map(match => {
+        //     const parts = match[1].split(' : ');
+        //     return parts[1]?.trim() ?? match[1];
+        // });
+        // toast.error(messages.join('\n') || '입력 값 검증 오류입니다.');
+    } else {
+        toast.error(raw || defaultMessage);
+    }
+}


### PR DESCRIPTION
closes #000
---

📌 개요
- 발령 및 사원 등록 로직 수정
- 토스트 알림 수정

🔨 주요 변경 사항
- `DeptList` 수정 (부서ID null 선택 못하는 경우에도 컴포넌트 사용하기 위함)
- 목록 조회 페이지들 토스트 알림 메시지 수정
  - `src/util/toastError.js` 생성
  - 유효값 검증 실패는 조회되는 첫 번째 메시지를 출력 (Spring `@Valid` 어노테이션)
  - 조회 API 호출 실패 시에는 message 받아오지 않고 직접 매핑 (그대로 받아오면 mybatis 오류인 경우 스택트레이스가 노출될 수 있음)

✅ 리뷰 요청 사항

⭐ 관련 이슈
#
