### PR TITLE
refactor: 내 정보 조회 페이지 수정

### DIFF
--- a/src/features/mypage/components/profile/HistoryInfo.vue
+++ b/src/features/mypage/components/profile/HistoryInfo.vue
@@ -41,19 +41,19 @@ import {onMounted, reactive} from "vue";
 //enum('EDUCATION','CERTIFICATE','AWARD','CAREER')
 const dataMap = reactive({
   EDUCATION: {
-    headers: ['학교명','학과','기간'],
+    headers: ['학교명','학과명','기간'],
     rows: []
   },
   CERTIFICATE: {
-    headers: ['자격증명', '발급 기관', '취득 시기'],
+    headers: ['자격증명', '발급 기관', '취득일'],
     rows: []
   },
   AWARD: {
-    headers: ['수상명', '수상 기관', '수상 시기'],
+    headers: ['수상명', '수상 기관', '수상일'],
     rows: []
   },
   CAREER: {
-    headers: ['근무지', '기간'],
+    headers: ['직장명', '기간'],
     rows: []
   }
 })
@@ -98,8 +98,8 @@ onMounted(() => {
         break
       case 'CAREER':
         dataMap.CAREER.rows.push([
+          item.organization,
           item.startDate+' ~ '+item.endDate,
-          item.organization
         ])
         break
     }


### PR DESCRIPTION
closes #000

---

📌 개요
- 인사 정보 페이지의 테이블 헤더 이름 변경

🔨 주요 변경 사항
- 직장명과 기간 순서가 반대로 매핑되던 문제 수정
- 관리자 프로필 조회와 헤더명 통일 (학과 -> 학과명, 취득 시기 -> 취득일 등)

✅ 리뷰 요청 사항
- 수정 전 이름이 더 적절하다면 수정 가능 (관리자 프로필 조회도 함께 수정)
- 관리자 프로필 조회에서는 DB insert를 위해 기간을 물결 형태가 아니라 시작일 종료일 형태로 나누어 작성하고 있음
  - 필요 시 내 정보 조회 페이지도 동일하게 수정

⭐ 관련 이슈
#85, #20
