### PR TITLE
[style] 인사 정보 수정 페이지, 알림 영역(NoticeItem, PositionForm) 스타일 수정

### DIFF
--- a/src/features/employee/components/NoticeItem.vue
+++ b/src/features/employee/components/NoticeItem.vue
@@ -19,7 +19,7 @@ const props = defineProps({
 <style scoped>
 .notice-item {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   padding: 12px;
   border-left-width: 4px;
   border-left-style: solid;

--- a/src/features/employee/components/profile/HistoryInfoEditable.vue
+++ b/src/features/employee/components/profile/HistoryInfoEditable.vue
@@ -169,7 +169,7 @@ watch(
         </thead>
         <tbody>
         <tr v-for="(item, index) in formData[section.key]" :key="index">
-          <td v-for="field in section.fields" :key="field">
+          <td v-for="field in section.fields" :key="field" :class="!isEditing ? 'table-value' : ''">
             <template v-if="isEditing">
               <input
                   v-model="item[field]"

--- a/src/features/settings/views/PositionForm.vue
+++ b/src/features/settings/views/PositionForm.vue
@@ -5,6 +5,7 @@ import {deletePosition, getPositions, postPosition, putPosition} from "@/feature
 import {useToast} from "vue-toastification";
 import DeleteConfirmToast from "@/components/common/DeleteConfirmToast.vue";
 import SideModal from "@/components/common/SideModal.vue";
+import NoticeItem from "@/features/employee/components/NoticeItem.vue";
 
 const toast = useToast();
 
@@ -145,10 +146,11 @@ onMounted(async () => {
   <div class="header">
     <!-- Additional Info -->
     <div class = "header-info">
-        <i class="fas fa-info-circle card-icon"></i>
-        <h3 class="font-semibold text-blue-900 mb-2">숫자가 작을수록 높은 직위 입니다.</h3>
-        <div>
-        </div>
+      <NoticeItem
+      icon="fa-info-circle"
+      text="숫자가 작을수록 높은 직위입니다."
+      color="blue"
+      />
     </div>
     <div class="header-buttons">
       <button class="create-button" @click="createModalVisible=true">
@@ -201,6 +203,10 @@ onMounted(async () => {
   gap: 10px;
   flex-direction: row;
   justify-items: center;
+}
+
+.create-button i {
+  margin-right: 8px;
 }
 
 .card-icon {


### PR DESCRIPTION
closes #000

---

📌 개요
- 관리자 사원 프로필 조회 중 인사 정보 수정 페이지 스타일 수정

🔨 주요 변경 사항
- 읽기 모드일 때, 내 정보 조회 페이지와 스타일 통일
  - 표 내부 값의 폰트 색상이 달랐던 문제 수정 (수정 전 폰트 색: #000000)
  
✅ 리뷰 요청 사항

⭐ 관련 이슈
#85, #20 
