### PR TITLE
fix : 수정 시 취소 결재 안되는 문제 해결

### DIFF
--- a/src/features/approvals/components/approveType/CancelForm.vue
+++ b/src/features/approvals/components/approveType/CancelForm.vue
@@ -75,7 +75,10 @@ onMounted(async () => {
     <div class="form-grid">
       <div class="form-group full-width">
         <label class="form-label required">취소 사유</label>
-        <input v-model="formData.cancelReason" class="form-textarea" readonly></input>
+        <textarea
+          v-model="formData.cancelReason"
+          :readonly="isReadOnly"
+          class="form-textarea"/>
       </div>
     </div>
   </div>

--- a/src/features/approvals/views/ApproveEditCreateView.vue
+++ b/src/features/approvals/views/ApproveEditCreateView.vue
@@ -181,7 +181,7 @@ onMounted(() => {
 
     <div class="header-buttons">
       <button class="blue-btn" @click="goBack">
-        <i class="fas fa-arrow-left"></i> 문서함
+        <i class="fas fa-arrow-left"></i>{{ isEditMode ? '이전으로' : '문서함' }}
       </button>
     </div>
   </div>


### PR DESCRIPTION
closes #000

---

📌 개요
취소 결재 수정되지 않는 문제 해결

🔨 주요 변경 사항
- 취소 결재는 `FormSection` 안에서 될 수 있게 수정
- `CancelForm`에서 edit 모드와 read 모드 구분
- 수정 모드라면 문서함이 아닌 이전으로 갈 수 있게 변경

✅ 리뷰 요청 사항

⭐ 관련 이슈
#
