### PR TITLE
refactor : KPI 승인,반려,취소 상태일 경우 처리 사유 수정 불가능, 인사 평가 조회 사원1번은 불가능하게 수정

### DIFF
--- a/src/components/common/Sidebar.vue
+++ b/src/components/common/Sidebar.vue
@@ -152,6 +152,7 @@ const openSubmenu = ref(null)
 const showAlertPanel = ref(false)
 const roundStatus = ref({inProgress: false, roundId: null})
 const companyName = ref('')
+const empId = ref(null)
 
 /* ======================== 출퇴근 상태 ======================== */
 const profile = reactive({
@@ -168,6 +169,7 @@ const getProfile = async () => {
     profile.name = emp.name
     profile.department = emp.deptName || '-'
     profile.position = emp.positionName || '-'
+    empId.value = emp.empId
   } catch (e) {
     console.error("사원 정보 불러오기 실패", e)
   }
@@ -302,6 +304,9 @@ const menuItems = [
 function isAllowed(item) {
   if (!item) return false
   if (typeof item.required === 'function' && !item.required()) return false
+  if (item.label === '인사 평가 조회' && empId.value === 1) {
+    return false
+  }
   if (!item.requireRole || item.requireRole.length === 0) return true
   return item.requireRole.some(role => userRole.value.includes(role))
 }

--- a/src/features/performance/views/KpiRequestsView.vue
+++ b/src/features/performance/views/KpiRequestsView.vue
@@ -117,7 +117,9 @@ const tabOptions = [
 // ───────── computed ─────────
 const canProgress = computed(() => {
   const detail = createForm.value;
-  return detail.statusType === 'PENDING' && new Date(detail.deadline) > new Date();
+  const isPendingRequest = detail.statusType === 'PENDING' && new Date(detail.deadline) > new Date();
+  const isCancelRequest = detail.statusType === 'PENDING' && detail.isDeleted === 'Y';
+  return isPendingRequest || isCancelRequest;
 });
 
 // ───────── 필터 정규화 함수 ─────────

--- a/src/features/performance/views/KpiRequestsView.vue
+++ b/src/features/performance/views/KpiRequestsView.vue
@@ -247,13 +247,13 @@ async function openModalHandler(kpiId) {
           {
             label: '처리 사유',
             key: 'reason',
-            editable: true,
+            editable: canProgress.value,
             type: 'textarea'
           },
           ...(detail.cancelReason
               ? [
                 { label: '취소 신청 사유', key: 'cancelReason', editable: false, type: 'input' },
-                { label: '취소 처리 사유', key: 'cancelResponse', editable: true, type: 'input' }
+                { label: '취소 처리 사유', key: 'cancelResponse', editable: canProgress.value, type: 'input' }
               ]
               : [])
         ]


### PR DESCRIPTION
closes #000

---

📌 개요

🔨 주요 변경 사항
- KPI 상태가 승인, 취소, 반려일 경우 모달의 처리 사유를 수정 불가능으로 변경
- 인사 평가 조회의 서브메뉴를 사원 1번일 경우 조회 불가능하도록 수정

✅ 리뷰 요청 사항

⭐ 관련 이슈
#
